### PR TITLE
Generalize models to 1D and 3D

### DIFF
--- a/src/autoden/models/msd.py
+++ b/src/autoden/models/msd.py
@@ -6,14 +6,25 @@ from typing import overload, Literal
 import torch as pt
 import torch.nn as nn
 
+NDConv = {1: nn.Conv1d, 2: nn.Conv2d, 3: nn.Conv3d}
+NDBatchNorm = {1: nn.BatchNorm1d, 2: nn.BatchNorm2d, 3: nn.BatchNorm3d}
+NDPool = {1: nn.AvgPool1d, 2: nn.AvgPool2d, 3: nn.AvgPool3d}
+NDPadding = {1: nn.ReplicationPad1d, 2: nn.ReplicationPad2d, 3: nn.ReplicationPad3d}
+NDUpsampling = {1: "linear", 2: "bilinear", 3: "trilinear"}
+
+
+def _get_alignment_padding(shape: tuple[int, ...], n_levels: int = 1, kernel_size: int = 1) -> tuple[int, ...]:
+    align_size = kernel_size * 2**n_levels
+    return sum([((-s % align_size) // 2, (-s % align_size) - (-s % align_size) // 2) for s in reversed(shape)], ())
+
 
 class DilatedConvBlock(nn.Sequential):
     """Dilated convolution block (dilated_conv => BN => ReLU)."""
 
-    def __init__(self, in_ch: int, out_ch: int, dilation: int = 1, pad_mode: str = "replicate") -> None:
+    def __init__(self, in_ch: int, out_ch: int, dilation: int = 1, pad_mode: str = "replicate", ndim: int = 2) -> None:
         super().__init__(
-            nn.Conv2d(in_ch, out_ch, 3, padding=dilation, dilation=dilation, padding_mode=pad_mode),
-            nn.BatchNorm2d(out_ch),
+            NDConv[ndim](in_ch, out_ch, 3, padding=dilation, dilation=dilation, padding_mode=pad_mode),
+            NDBatchNorm[ndim](out_ch),
             nn.LeakyReLU(0.2, inplace=True),
         )
 
@@ -21,27 +32,28 @@ class DilatedConvBlock(nn.Sequential):
 class SamplingConvBlock(nn.Sequential):
     """Down-sampling convolution module (down-samp => conv => BN => ReLU => up-samp)."""
 
-    def __init__(self, in_ch: int, out_ch: int, samp_factor: int = 1) -> None:
+    def __init__(self, in_ch: int, out_ch: int, samp_factor: int = 1, ndim: int = 2) -> None:
         if samp_factor > 1:
-            pre = [nn.AvgPool2d(samp_factor)]
-            post = [nn.Upsample(scale_factor=samp_factor, mode="bilinear", align_corners=True)]
+            pre = [NDPool[ndim](samp_factor)]
+            post = [nn.Upsample(scale_factor=samp_factor, mode=NDUpsampling[ndim], align_corners=True)]
         else:
             pre = post = []
         super().__init__(
-            *pre, nn.Conv2d(in_ch, out_ch, 3, padding=1), nn.BatchNorm2d(out_ch), nn.LeakyReLU(0.2, inplace=True), *post
+            *pre, NDConv[ndim](in_ch, out_ch, 3, padding=1), NDBatchNorm[ndim](out_ch), nn.LeakyReLU(0.2, inplace=True), *post
         )
 
 
 class MSDSampBlock(nn.Module):
     """MS-D Block containing the sequence of dilated convolutional layers."""
 
-    def __init__(self, n_channels_in: int, n_features: int, n_layers: int, dilations: Sequence[int]) -> None:
+    def __init__(self, n_channels_in: int, n_features: int, n_layers: int, dilations: Sequence[int], ndim: int = 2) -> None:
         super().__init__()
         self.n_features = n_features
         self.n_layers = n_layers
         self.dilations = dilations
+        self.ndim = ndim
         convs = [
-            SamplingConvBlock(n_channels_in + n_features * ii, n_features, samp_factor=self._layer_sampling(ii))
+            SamplingConvBlock(n_channels_in + n_features * ii, n_features, samp_factor=self._layer_sampling(ii), ndim=ndim)
             for ii in range(n_layers)
         ]
         self.convs = nn.ModuleList(convs)
@@ -51,32 +63,29 @@ class MSDSampBlock(nn.Module):
         return 2 ** (self.dilations[ind % len(self.dilations)] - 1)
 
     def forward(self, x: pt.Tensor) -> pt.Tensor:
-        max_dilation_span = 3 * 2 ** (max(self.dilations) - 1)
-        img_size = x.shape[2:]
-        img_pad_total = [-s % max_dilation_span for s in img_size]
-        padding = [(s // 2, s - s // 2) for s in img_pad_total]
-        pad_input = nn.ReplicationPad2d((*padding[-2], *padding[-1]))
+        padding = _get_alignment_padding(x.shape[2:], n_levels=max(self.dilations) - 1, kernel_size=3)
+        pad_input = NDPadding[self.ndim](padding)
 
         latent = [pad_input(x)]
         for conv in self.convs:
             latent.append(conv(pt.cat(latent, dim=1)))
         latent = pt.cat(latent, dim=1)
 
-        crop_w = padding[-2][0], padding[-2][0] + img_size[-2]
-        crop_h = padding[-1][0], padding[-1][0] + img_size[-1]
-        return latent[..., crop_w[0] : crop_w[1], crop_h[0] : crop_h[1]]
+        crop = [slice(None)] * 2 + [slice(p, p + s) for p, s in zip(padding[::2], x.shape[2:])]
+        return latent[tuple(crop)]
 
 
 class MSDDilBlock(nn.Module):
     """MS-D Block containing the sequence of dilated convolutional layers."""
 
-    def __init__(self, n_channels_in: int, n_features: int, n_layers: int, dilations: Sequence[int]) -> None:
+    def __init__(self, n_channels_in: int, n_features: int, n_layers: int, dilations: Sequence[int], ndim: int = 2) -> None:
         super().__init__()
         self.n_features = n_features
         self.n_layers = n_layers
         self.dilations = dilations
+        self.ndim = ndim
         convs = [
-            DilatedConvBlock(n_channels_in + n_features * ii, n_features, dilation=self._layer_dilation(ii))
+            DilatedConvBlock(n_channels_in + n_features * ii, n_features, dilation=self._layer_dilation(ii), ndim=ndim)
             for ii in range(n_layers)
         ]
         self.convs = nn.ModuleList(convs)
@@ -91,13 +100,6 @@ class MSDDilBlock(nn.Module):
             latent.append(conv(pt.cat(latent, dim=1)))
         return pt.cat(latent, dim=1)
 
-        # latent = pt.cat([x, x.new_empty(x.shape[0], self.n_features * self.n_layers, *x.shape[2:])], dim=1)
-        # for ii, conv in enumerate(self.convs):
-        #     ii_s = x.shape[1] + self.n_features * ii
-        #     ii_e = ii_s + self.n_features
-        #     latent[:, ii_s:ii_e, ...] = conv(latent[:, :ii_s, ...])
-        # return latent
-
 
 class MSDnet(nn.Module):
     """Simple MS-D net implementation."""
@@ -111,6 +113,7 @@ class MSDnet(nn.Module):
         dilations: Sequence[int] = [1, 2, 3, 4],
         device: str = "cuda" if pt.cuda.is_available() else "cpu",
         use_dilations: bool = True,
+        ndim: int = 2,
     ) -> None:
         init_params = locals()
         del init_params["self"]
@@ -121,10 +124,10 @@ class MSDnet(nn.Module):
         self.device = device
 
         if use_dilations:
-            self.msd_block = MSDDilBlock(n_channels_in, n_features, n_layers, dilations)
+            self.msd_block = MSDDilBlock(n_channels_in, n_features, n_layers, dilations, ndim=ndim)
         else:
-            self.msd_block = MSDSampBlock(n_channels_in, n_features, n_layers, dilations)
-        self.outc = nn.Conv2d(n_channels_in + n_features * n_layers, n_channels_out, kernel_size=1)
+            self.msd_block = MSDSampBlock(n_channels_in, n_features, n_layers, dilations, ndim=ndim)
+        self.outc = NDConv[ndim](n_channels_in + n_features * n_layers, n_channels_out, kernel_size=1)
 
         self.to(self.device)
 

--- a/tests/models/test_dncnn.py
+++ b/tests/models/test_dncnn.py
@@ -4,90 +4,100 @@ import torch.nn as nn
 from autoden.models.dncnn import ConvBlock, DnCNN
 
 
-def test_conv_block_initialization():
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_conv_block_initialization(ndim):
     """
     Test the initialization of ConvBlock.
     Ensures that the ConvBlock is correctly initialized with the expected layers.
     """
-    conv_block = ConvBlock(in_ch=3, out_ch=32, kernel_size=3)
+    conv_block = ConvBlock(in_ch=3, out_ch=32, kernel_size=3, ndim=ndim)
     assert isinstance(conv_block, nn.Sequential)
-    assert len(conv_block) == 3  # Conv2d, BatchNorm2d, LeakyReLU
+    assert len(conv_block) == 3  # Conv, BatchNorm, LeakyReLU
 
-    conv_block_last = ConvBlock(in_ch=32, out_ch=3, kernel_size=3, last_block=True)
+    conv_block_last = ConvBlock(in_ch=32, out_ch=3, kernel_size=3, ndim=ndim, last_block=True)
     assert isinstance(conv_block_last, nn.Sequential)
-    assert len(conv_block_last) == 1  # Only Conv2d
+    assert len(conv_block_last) == 1  # Only Conv
 
 
-def test_conv_block_forward_pass():
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
+def test_conv_block_forward_pass(ndim, shape):
     """
     Test the forward pass of ConvBlock.
     Ensures that the output tensor has the expected shape.
     """
-    conv_block = ConvBlock(in_ch=3, out_ch=32, kernel_size=3)
-    input_tensor = torch.randn(1, 3, 64, 64)
+    conv_block = ConvBlock(in_ch=3, out_ch=32, kernel_size=3, ndim=ndim)
+    input_tensor = torch.randn(*shape)
     output_tensor = conv_block(input_tensor)
-    assert output_tensor.shape == (1, 32, 64, 64)
+    assert output_tensor.shape == (1, 32, *shape[2:])
 
-    conv_block_last = ConvBlock(in_ch=32, out_ch=3, kernel_size=3, last_block=True)
-    input_tensor = torch.randn(1, 32, 64, 64)
+    conv_block_last = ConvBlock(in_ch=32, out_ch=3, kernel_size=3, ndim=ndim, last_block=True)
+    input_tensor = torch.randn(1, 32, *shape[2:])
     output_tensor = conv_block_last(input_tensor)
-    assert output_tensor.shape == (1, 3, 64, 64)
+    assert output_tensor.shape == (1, 3, *shape[2:])
 
 
-def test_dncnn_initialization():
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_dncnn_initialization(ndim):
     """
     Test the initialization of DnCNN.
     Ensures that the DnCNN is correctly initialized with the expected number of layers.
     """
-    dncnn = DnCNN(n_channels_in=3, n_channels_out=3)
+    dncnn = DnCNN(n_channels_in=3, n_channels_out=3, ndim=ndim)
     assert isinstance(dncnn, nn.Sequential)
     assert len(dncnn) == 20  # Default number of layers is 20
 
-    dncnn_custom = DnCNN(n_channels_in=3, n_channels_out=3, n_layers=10, n_features=64, kernel_size=5)
+    dncnn_custom = DnCNN(n_channels_in=3, n_channels_out=3, n_layers=10, n_features=64, kernel_size=5, ndim=ndim)
     assert isinstance(dncnn_custom, nn.Sequential)
     assert len(dncnn_custom) == 10  # Custom number of layers is 10
 
 
-def test_dncnn_forward_pass():
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
+def test_dncnn_forward_pass(ndim, shape):
     """
     Test the forward pass of DnCNN.
     Ensures that the output tensor has the expected shape.
     """
-    dncnn = DnCNN(n_channels_in=3, n_channels_out=3)
-    input_tensor = torch.randn(1, 3, 64, 64, device=dncnn.device)
+    dncnn = DnCNN(n_channels_in=3, n_channels_out=3, ndim=ndim)
+    input_tensor = torch.randn(*shape, device=dncnn.device)
     output_tensor = dncnn(input_tensor)
-    assert output_tensor.shape == (1, 3, 64, 64)
+    assert output_tensor.shape == (1, 3, *shape[2:])
 
 
-def test_dncnn_device_handling():
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_dncnn_device_handling(ndim):
     """
     Test the device handling of DnCNN.
     Ensures that the DnCNN is correctly assigned to the specified device.
     """
-    dncnn = DnCNN(n_channels_in=3, n_channels_out=3, device='cpu')
+    dncnn = DnCNN(n_channels_in=3, n_channels_out=3, ndim=ndim, device='cpu')
     assert dncnn.device == 'cpu'
 
     if torch.cuda.is_available():
-        dncnn = DnCNN(n_channels_in=3, n_channels_out=3, device='cuda')
+        dncnn = DnCNN(n_channels_in=3, n_channels_out=3, ndim=ndim, device='cuda')
         assert dncnn.device == 'cuda'
 
 
-def test_dncnn_invalid_device():
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_dncnn_invalid_device(ndim):
     """
     Test the handling of an invalid device for DnCNN.
     Ensures that a ValueError is raised when an invalid device is specified.
     """
     with pytest.raises(RuntimeError):
-        DnCNN(n_channels_in=3, n_channels_out=3, device='invalid_device')
+        DnCNN(n_channels_in=3, n_channels_out=3, ndim=ndim, device='invalid_device')
 
 
-def test_dncnn_invalid_input_shape():
+@pytest.mark.parametrize(
+    "ndim,inv_shape",
+    [(1, (1, 3, 64, 64)), (2, (1, 3, 64, 64, 64)), (3, (1, 3, 64, 64))],  # Invalid for 1D  # Invalid for 2D  # Invalid for 3D
+)
+def test_dncnn_invalid_input_shape(ndim, inv_shape):
     """
     Test the handling of an invalid input shape for DnCNN.
     Ensures that a RuntimeError is raised when the input tensor has an invalid shape.
     """
-    dncnn = DnCNN(n_channels_in=3, n_channels_out=3)
-    input_tensor = torch.randn(1, 3, 64, 64, 64)  # Invalid shape
+    dncnn = DnCNN(n_channels_in=3, n_channels_out=3, ndim=ndim)
+    input_tensor = torch.randn(*inv_shape)
     with pytest.raises(RuntimeError):
         dncnn(input_tensor)
 

--- a/tests/models/test_msd.py
+++ b/tests/models/test_msd.py
@@ -3,111 +3,112 @@ import torch as pt
 from autoden.models.msd import MSDnet, DilatedConvBlock, SamplingConvBlock, MSDSampBlock, MSDDilBlock
 
 
-@pytest.fixture
-def sample_input():
-    """
-    Fixture to generate a sample input tensor for testing.
-
-    Returns:
-        pt.Tensor: A tensor of shape (1, 1, 64, 64) representing a batch of 1 image with 1 channel and size 64x64.
-    """
-    return pt.randn(1, 1, 64, 64)
-
-
-def test_dilated_conv_block():
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
+def test_dilated_conv_block(ndim, shape):
     """
     Test the DilatedConvBlock to ensure it outputs the correct shape.
 
-    The input tensor has shape (1, 1, 64, 64), and the output tensor should have shape (1, 16, 64, 64).
+    The input tensor has shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32), and the output tensor should have shape (1, 16, 64), (1, 16, 64, 64), or (1, 16, 16, 32, 32).
     """
-    block = DilatedConvBlock(1, 16, dilation=1)
-    input_tensor = pt.randn(1, 1, 64, 64)
+    block = DilatedConvBlock(1, 16, dilation=1, ndim=ndim)
+    input_tensor = pt.randn(*shape)
     output_tensor = block(input_tensor)
-    assert output_tensor.shape == (1, 16, 64, 64)
+    assert output_tensor.shape == (1, 16, *shape[2:])
 
-    block = DilatedConvBlock(1, 16, dilation=2)
-    input_tensor = pt.randn(1, 1, 64, 64)
+    block = DilatedConvBlock(1, 16, dilation=2, ndim=ndim)
+    input_tensor = pt.randn(*shape)
     output_tensor = block(input_tensor)
-    assert output_tensor.shape == (1, 16, 64, 64)
+    assert output_tensor.shape == (1, 16, *shape[2:])
 
 
-def test_sampling_conv_block():
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
+def test_sampling_conv_block(ndim, shape):
     """
     Test the SamplingConvBlock to ensure it outputs the correct shape.
 
-    The input tensor has shape (1, 1, 64, 64), and the output tensor should have shape (1, 16, 32, 32) due to down-sampling.
+    The input tensor has shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32), and the output tensor should have shape (1, 16, 32), (1, 16, 32, 32), or (1, 16, 8, 16, 16) due to down-sampling.
     """
-    block = SamplingConvBlock(1, 16, samp_factor=2)
-    input_tensor = pt.randn(1, 1, 64, 64)
+    block = SamplingConvBlock(1, 16, samp_factor=2, ndim=ndim)
+    input_tensor = pt.randn(*shape)
     output_tensor = block(input_tensor)
-    assert output_tensor.shape == (1, 16, 64, 64)
+    assert output_tensor.shape == (1, 16, *shape[2:])
 
-    block = SamplingConvBlock(1, 16, samp_factor=4)
-    input_tensor = pt.randn(1, 1, 64, 64)
+    block = SamplingConvBlock(1, 16, samp_factor=4, ndim=ndim)
+    input_tensor = pt.randn(*shape)
     output_tensor = block(input_tensor)
-    assert output_tensor.shape == (1, 16, 64, 64)
+    assert output_tensor.shape == (1, 16, *shape[2:])
 
-    block = SamplingConvBlock(1, 16, samp_factor=3)
-    input_tensor = pt.randn(1, 1, 64, 64)
+    block = SamplingConvBlock(1, 16, samp_factor=3, ndim=ndim)
+    input_tensor = pt.randn(*shape)
     output_tensor = block(input_tensor)
-    assert output_tensor.shape != (1, 16, 64, 64)
+    assert output_tensor.shape != (1, 16, *shape[2:])
 
 
-def test_msd_samp_block(sample_input):
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
+def test_msd_samp_block(ndim, shape):
     """
     Test the MSDSampBlock to ensure it outputs the correct shape.
 
-    The input tensor has shape (1, 1, 64, 64), and the output tensor should have shape (1, 16 * 3, 64, 64).
+    The input tensor has shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32), and the output tensor should have shape (1, 16 * 3 + 1, 64), (1, 16 * 3 + 1, 64, 64), or (1, 16 * 3 + 1, 16, 32, 32).
     """
-    block = MSDSampBlock(1, 16, 3, [1, 2, 3])
-    output_tensor = block(sample_input)
-    assert output_tensor.shape == (1, 16 * 3 + 1, 64, 64)
+    block = MSDSampBlock(1, 16, 3, [1, 2, 3], ndim=ndim)
+    input_tensor = pt.randn(*shape)
+    output_tensor = block(input_tensor)
+    assert output_tensor.shape == (1, 16 * 3 + 1, *shape[2:])
 
 
-def test_msd_dil_block(sample_input):
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
+def test_msd_dil_block(ndim, shape):
     """
     Test the MSDDilBlock to ensure it outputs the correct shape.
 
-    The input tensor has shape (1, 1, 64, 64), and the output tensor should have shape (1, 16 * 3, 64, 64).
+    The input tensor has shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32), and the output tensor should have shape (1, 16 * 3 + 1, 64), (1, 16 * 3 + 1, 64, 64), or (1, 16 * 3 + 1, 16, 32, 32).
     """
-    block = MSDDilBlock(1, 16, 3, [1, 2, 3])
-    output_tensor = block(sample_input)
-    assert output_tensor.shape == (1, 16 * 3 + 1, 64, 64)
+    block = MSDDilBlock(1, 16, 3, [1, 2, 3], ndim=ndim)
+    input_tensor = pt.randn(*shape)
+    output_tensor = block(input_tensor)
+    assert output_tensor.shape == (1, 16 * 3 + 1, *shape[2:])
 
 
-def test_msdnet_forward(sample_input):
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
+def test_msdnet_forward(ndim, shape):
     """
     Test the MSDnet forward pass to ensure it outputs the correct shape.
 
-    The input tensor has shape (1, 1, 64, 64), and the output tensor should have shape (1, 1, 64, 64).
+    The input tensor has shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32), and the output tensor should have shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32).
     """
-    model = MSDnet(n_channels_in=1, n_channels_out=1, n_layers=3, n_features=16, use_dilations=True)
-    output_tensor = model(sample_input.to(device=model.device))
-    assert output_tensor.shape == (1, 1, 64, 64)
+    model = MSDnet(n_channels_in=1, n_channels_out=1, n_layers=3, n_features=16, use_dilations=True, ndim=ndim)
+    input_tensor = pt.randn(*shape, device=model.device)
+    output_tensor = model(input_tensor)
+    assert output_tensor.shape == (1, 1, *shape[2:])
 
 
-def test_msdnet_forward_with_latent(sample_input):
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
+def test_msdnet_forward_with_latent(ndim, shape):
     """
     Test the MSDnet forward pass with the return_latent flag to ensure it outputs both the correct output and latent tensors.
 
-    The input tensor has shape (1, 1, 64, 64), and the output tensor should have shape (1, 1, 64, 64).
-    The latent tensor should have shape (1, 16 * 3, 64, 64).
+    The input tensor has shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32), and the output tensor should have shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32).
+    The latent tensor should have shape (1, 16 * 3 + 1, 64), (1, 16 * 3 + 1, 64, 64), or (1, 16 * 3 + 1, 16, 32, 32).
     """
-    model = MSDnet(n_channels_in=1, n_channels_out=1, n_layers=3, n_features=16, use_dilations=True)
-    output_tensor, latent_tensor = model(sample_input.to(device=model.device), return_latent=True)
-    assert output_tensor.shape == (1, 1, 64, 64)
-    assert latent_tensor.shape == (1, 16 * 3 + 1, 64, 64)
+    model = MSDnet(n_channels_in=1, n_channels_out=1, n_layers=3, n_features=16, use_dilations=True, ndim=ndim)
+    input_tensor = pt.randn(*shape, device=model.device)
+    output_tensor, latent_tensor = model(input_tensor, return_latent=True)
+    assert output_tensor.shape == (1, 1, *shape[2:])
+    assert latent_tensor.shape == (1, 16 * 3 + 1, *shape[2:])
 
 
-def test_msdnet_use_sampling(sample_input):
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
+def test_msdnet_use_sampling(ndim, shape):
     """
     Test the MSDnet with the use_dilations flag set to False to ensure it outputs the correct shape.
 
-    The input tensor has shape (1, 1, 64, 64), and the output tensor should have shape (1, 1, 64, 64).
+    The input tensor has shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32), and the output tensor should have shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32).
     """
-    model = MSDnet(n_channels_in=1, n_channels_out=1, n_layers=3, n_features=16, use_dilations=False)
-    output_tensor = model(sample_input.to(device=model.device))
-    assert output_tensor.shape == (1, 1, 64, 64)
+    model = MSDnet(n_channels_in=1, n_channels_out=1, n_layers=3, n_features=16, use_dilations=False, ndim=ndim)
+    input_tensor = pt.randn(*shape, device=model.device)
+    output_tensor = model(input_tensor)
+    assert output_tensor.shape == (1, 1, *shape[2:])
 
 
 if __name__ == "__main__":

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -1,68 +1,72 @@
 import pytest
 import torch as pt
-import torch.nn as nn
 from src.autoden.models.resnet import ResBlock, Resnet
 
 
-def test_resblock_forward():
+@pytest.mark.parametrize("ndim,shape", [(1, (2, 3, 32)), (2, (2, 3, 32, 32)), (3, (2, 3, 8, 16, 16))])
+def test_resblock_forward(ndim, shape):
     """Test ResBlock forward pass."""
-    batch_size = 2
-    in_ch = 3
+    batch_size, in_ch, *spatial_dims = shape
     out_ch = 64
     kernel_size = 3
-    inp = pt.randn(batch_size, in_ch, 32, 32)
 
-    resblock = ResBlock(in_ch, out_ch, kernel_size)
+    inp = pt.randn(*shape)
+
+    resblock = ResBlock(in_ch, out_ch, kernel_size, ndim=ndim)
     out = resblock(inp)
 
-    assert out.shape == (batch_size, out_ch, 32, 32)
+    assert out.shape == (batch_size, out_ch, *spatial_dims)
 
 
-def test_resblock_forward_with_scale():
+@pytest.mark.parametrize("ndim,shape", [(1, (2, 3, 32)), (2, (2, 3, 32, 32)), (3, (2, 3, 8, 16, 16))])
+def test_resblock_forward_with_scale(ndim, shape):
     """Test ResBlock forward pass with scaling."""
-    batch_size = 2
-    in_ch = 3
+    batch_size, in_ch, *spatial_dims = shape
     out_ch = 64
     kernel_size = 3
-    inp = pt.randn(batch_size, in_ch, 32, 32)
 
-    resblock = ResBlock(in_ch, out_ch, kernel_size)
+    inp = pt.randn(*shape)
+
+    resblock = ResBlock(in_ch, out_ch, kernel_size, ndim=ndim)
     out = resblock(inp)
 
-    assert out.shape == (batch_size, out_ch, 32, 32)
+    assert out.shape == (batch_size, out_ch, *spatial_dims)
 
 
-def test_resblock_forward_last_block():
+@pytest.mark.parametrize("ndim,shape", [(1, (2, 3, 32)), (2, (2, 3, 32, 32)), (3, (2, 3, 8, 16, 16))])
+def test_resblock_forward_last_block(ndim, shape):
     """Test ResBlock forward pass with last_block=True."""
-    batch_size = 2
-    in_ch = 3
+    batch_size, in_ch, *spatial_dims = shape
     out_ch = 64
     kernel_size = 3
-    inp = pt.randn(batch_size, in_ch, 32, 32)
 
-    resblock = ResBlock(in_ch, out_ch, kernel_size, last_block=True)
+    inp = pt.randn(*shape)
+
+    resblock = ResBlock(in_ch, out_ch, kernel_size, ndim=ndim, last_block=True)
     out = resblock(inp)
 
-    assert out.shape == (batch_size, out_ch, 32, 32)
+    assert out.shape == (batch_size, out_ch, *spatial_dims)
 
 
-def test_resnet_forward():
+@pytest.mark.parametrize("ndim,shape", [(1, (2, 3, 32)), (2, (2, 3, 32, 32)), (3, (2, 3, 8, 16, 16))])
+def test_resnet_forward(ndim, shape):
     """Test Resnet forward pass."""
-    batch_size = 2
-    n_channels_in = 3
+    batch_size, n_channels_in, *spatial_dims = shape
     n_channels_out = 64
     n_layers = 5
     n_features = 32
     kernel_size = 3
-    inp = pt.randn(batch_size, n_channels_in, 32, 32)
 
-    resnet = Resnet(n_channels_in, n_channels_out, n_layers, n_features, kernel_size)
+    inp = pt.randn(*shape)
+
+    resnet = Resnet(n_channels_in, n_channels_out, n_layers, n_features, kernel_size, ndim=ndim)
     out = resnet(inp.to(resnet.device))
 
-    assert out.shape == (batch_size, n_channels_out, 32, 32)
+    assert out.shape == (batch_size, n_channels_out, *spatial_dims)
 
 
-def test_resnet_init_params():
+@pytest.mark.parametrize("ndim", [1, 2, 3])
+def test_resnet_init_params(ndim):
     """Test Resnet initialization parameters."""
     n_channels_in = 3
     n_channels_out = 64
@@ -70,13 +74,14 @@ def test_resnet_init_params():
     n_features = 32
     kernel_size = 3
 
-    resnet = Resnet(n_channels_in, n_channels_out, n_layers, n_features, kernel_size)
+    resnet = Resnet(n_channels_in, n_channels_out, n_layers, n_features, kernel_size, ndim=ndim)
 
     assert resnet.init_params['n_channels_in'] == n_channels_in
     assert resnet.init_params['n_channels_out'] == n_channels_out
     assert resnet.init_params['n_layers'] == n_layers
     assert resnet.init_params['n_features'] == n_features
     assert resnet.init_params['kernel_size'] == kernel_size
+    assert resnet.init_params['ndim'] == ndim
 
 
 if __name__ == "__main__":

--- a/tests/models/test_unet.py
+++ b/tests/models/test_unet.py
@@ -3,52 +3,59 @@ import torch as pt
 from autoden.models.unet import UNet, _compute_architecture, ConvBlock, DoubleConv, DownBlock, UpBlock
 
 
-def test_compute_architecture():
+@pytest.mark.parametrize("n_skip", [None, 8, 16, 64])
+def test_compute_architecture(n_skip):
     """Test the architecture computation function"""
-    encoder, decoder = _compute_architecture(n_levels=3, n_features=32, n_skip=None)
+    n_levels = 3
+    encoder, decoder = _compute_architecture(n_levels=n_levels, n_features=32, n_skip=n_skip, verbose=True)
     assert len(encoder) == 3
     assert len(decoder) == 3
     assert encoder[0] == (32, 64)
-    assert decoder[0] == (128, None, 64)
+    assert decoder[0] == (128, n_skip * (2 ** (n_levels - 1)) if n_skip is not None else None, 64)
 
 
-def test_conv_block():
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
+def test_conv_block(ndim, shape):
     """Test the ConvBlock class"""
-    block = ConvBlock(in_ch=3, out_ch=64, kernel_size=3)
-    inp = pt.randn(1, 3, 64, 64)
+    block = ConvBlock(in_ch=3, out_ch=64, ndim=ndim, kernel_size=3)
+    inp = pt.randn(*shape)
     out = block(inp)
-    assert out.shape == (1, 64, 64, 64)
+    assert out.shape == (1, 64, *shape[2:])
 
 
-def test_double_conv():
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
+def test_double_conv(ndim, shape):
     """Test the DoubleConv class"""
-    block = DoubleConv(in_ch=3, out_ch=64)
-    inp = pt.randn(1, 3, 64, 64)
+    block = DoubleConv(in_ch=3, out_ch=64, ndim=ndim)
+    inp = pt.randn(*shape)
     out = block(inp)
-    assert out.shape == (1, 64, 64, 64)
+    assert out.shape == (1, 64, *shape[2:])
 
 
-def test_down_block():
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
+def test_down_block(ndim, shape):
     """Test the DownBlock class"""
-    block = DownBlock(in_ch=3, out_ch=64)
-    inp = pt.randn(1, 3, 64, 64)
+    block = DownBlock(in_ch=3, out_ch=64, ndim=ndim)
+    inp = pt.randn(*shape)
     out = block(inp)
-    assert out.shape == (1, 64, 32, 32)
+    expected_shape = tuple(s // 2 for s in shape[2:])
+    assert out.shape == (1, 64, *expected_shape)
 
 
-def test_up_block():
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 64, 32)), (2, (1, 64, 32, 32)), (3, (1, 64, 8, 16, 16))])
+def test_up_block(ndim, shape):
     """Test the UpBlock class"""
-    block = UpBlock(in_ch=64, skip_ch=None, out_ch=32)
-    inp_lo_res = pt.randn(1, 64, 32, 32)
-    inp_hi_res = pt.randn(1, 64, 64, 64)
+    block = UpBlock(in_ch=shape[1], skip_ch=None, out_ch=32, ndim=ndim)
+    inp_lo_res = pt.randn(*shape)
+    inp_hi_res = pt.randn(*shape[:2], *(s * 2 for s in shape[2:]))
     out = block(inp_lo_res, inp_hi_res)
-    assert out.shape == (1, 32, 64, 64)
+    assert out.shape == (shape[0], 32, *(s * 2 for s in shape[2:]))
 
-    block = UpBlock(in_ch=64, skip_ch=8, out_ch=32)
-    inp_lo_res = pt.randn(1, 64, 32, 32)
-    inp_hi_res = pt.randn(1, 64, 64, 64)
+    block = UpBlock(in_ch=shape[1], skip_ch=8, out_ch=32, ndim=ndim)
+    inp_lo_res = pt.randn(*shape)
+    inp_hi_res = pt.randn(*shape[:2], *(s * 2 for s in shape[2:]))
     out = block(inp_lo_res, inp_hi_res)
-    assert out.shape == (1, 32, 64, 64)
+    assert out.shape == (shape[0], 32, *(s * 2 for s in shape[2:]))
 
 
 def test_unet_initialization():
@@ -60,20 +67,22 @@ def test_unet_initialization():
     assert len(model.decoder_layers) == 3
 
 
-def test_unet_forward_pass():
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
+def test_unet_forward_pass(ndim, shape):
     """Test the UNet forward pass"""
-    model = UNet(n_channels_in=3, n_channels_out=1, n_features=32, n_levels=3)
-    inp = pt.randn(1, 3, 64, 64, device=model.device)
+    model = UNet(n_channels_in=3, n_channels_out=1, ndim=ndim, n_features=32, n_levels=3)
+    inp = pt.randn(*shape, device=model.device)
     out = model(inp)
-    assert out.shape == (1, 1, 64, 64)
+    assert out.shape == (1, 1, *shape[2:])
 
 
-def test_unet_forward_pass_with_latent():
+@pytest.mark.parametrize("ndim,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
+def test_unet_forward_pass_with_latent(ndim, shape):
     """Test the UNet forward pass with latent return"""
-    model = UNet(n_channels_in=3, n_channels_out=1, n_features=32, n_levels=3)
-    inp = pt.randn(1, 3, 64, 64, device=model.device)
+    model = UNet(n_channels_in=3, n_channels_out=1, ndim=ndim, n_features=32, n_levels=3)
+    inp = pt.randn(*shape, device=model.device)
     out, latent = model(inp, return_latent=True)
-    assert out.shape == (1, 1, 64, 64)
+    assert out.shape == (1, 1, *shape[2:])
     assert isinstance(latent, pt.Tensor)
 
 


### PR DESCRIPTION
## Description

Currently, we only support 2D images, which limits the applications to just single images or stacks of them. This PR is a first step towards supporting 1D and 3D signals, by generalizing the provided models to 1D and 3D convolutions.

## TODO

- [x] Implement the support for 1D and 3D signals:
  - [x] UNet
  - [x] MS-D net
  - [x] DnCNN
  - [x] ResNet
- [x] Add/update docstrings
- [x] Add/update test

## Notes

This is just a first step towards enabling 1D and 3D signals support, but it is a pre-requisite for the algorithm changes down the line.