### PR TITLE
Add support for 1D & 3D signals

### DIFF
--- a/docs/tutorials/denoising.md
+++ b/docs/tutorials/denoising.md
@@ -61,6 +61,27 @@ net_params = ad.NetworkParamsUNet(n_features=16)
 The variable `net_params` only defines the type of architecture that we want. When passed to the denoising algorithms, they will use it to create and initialize a U-net model.
 Other pre-configured models are available: MS-D net [[2](#ref.2)], DnCNN [[3](#ref.3)], and a custom ResNet implementation [[4](#ref.4)].
 
+### 1D and 3D signals
+
+We have recently introduced the support for 1D and 3D signals in `auto-denoise`.
+To correctly process these signals, it is enough to instantiate a model with the correct dimensionality.
+This means that we need to set the correct value for the parameter `n_dims` in the model definition:
+```python
+net_params = ad.NetworkParamsUNet(n_features=16, n_dims=1)  # 1D Convolutions
+```
+or
+```python
+net_params = ad.NetworkParamsUNet(n_features=16, n_dims=3)  # 3D Convolutions
+```
+
+!!! node "Using a 2D model with 3D data"
+
+    It is possible to use a 3D dataset with a 2D model. The depth direction will be interpreted as the batch dimension.
+    The 2D model will interpret each volume slice as a different image example.
+
+    This could be useful in GPU memory constrained scenarios, where the higher memory requirements of 3D convolutions (w.r.t. 2D convolutions) could exceed the available GPU memory.
+    This technique could save around 30\% memory, but it would lose the information along the depth direction.
+
 ### Supervised Denoiser
 
 The supervised denoiser is trained using pairs of noisy and clean images. It learns to map noisy images to their clean counterparts.

--- a/examples/04_Comparison_3D.ipynb
+++ b/examples/04_Comparison_3D.ipynb
@@ -1,0 +1,216 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import skimage.data as skd\n",
+    "import skimage.transform as skt\n",
+    "from copy import deepcopy\n",
+    "from numpy.typing import NDArray\n",
+    "from tqdm.auto import tqdm\n",
+    "import autoden as ad\n",
+    "\n",
+    "\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "%matplotlib widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NUM_IMGS_TRN = 4\n",
+    "NUM_IMGS_TST = 2\n",
+    "NUM_IMGS_TOT = NUM_IMGS_TRN + NUM_IMGS_TST\n",
+    "\n",
+    "EPOCHS = 1024\n",
+    "REG_TV_VAL = 1e-7\n",
+    "\n",
+    "vol_orig = skd.cells3d()[:, 1, ...]\n",
+    "vol_orig = skt.downscale_local_mean(vol_orig, (2, 4, 4))\n",
+    "vol_orig = (vol_orig - vol_orig.min()) / (vol_orig.max() - vol_orig.min())\n",
+    "\n",
+    "vols_noisy: NDArray = np.stack(\n",
+    "    [(vol_orig + 0.2 * np.random.randn(*vol_orig.shape)) for _ in tqdm(range(NUM_IMGS_TOT), desc=\"Create noisy images\")],\n",
+    "    axis=0,\n",
+    ")\n",
+    "tst_inds = np.arange(NUM_IMGS_TRN, NUM_IMGS_TOT)\n",
+    "\n",
+    "print(f\"Img orig -> [{vol_orig.min()}, {vol_orig.max()}], Img noisy -> [{vols_noisy[0].min()}, {vols_noisy[0].max()}]\")\n",
+    "print(f\"Img shape: {vol_orig.shape}\")\n",
+    "\n",
+    "central_slice = vol_orig.shape[0] // 2\n",
+    "fig, axs = plt.subplots(1, 2, sharex=True, sharey=True, figsize=(8, 4))\n",
+    "axs[0].imshow(vol_orig[central_slice])\n",
+    "axs[1].imshow(vols_noisy[0][central_slice])\n",
+    "fig.tight_layout()\n",
+    "plt.show(block=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Performing training and prediction\n",
+    "\n",
+    "### Creating the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "net_params = ad.NetworkParamsUNet(n_features=16, n_dims=3)\n",
+    "model = net_params.get_model()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Training the same initial model with different algorithms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "denoiser_sup = ad.Supervised(model=deepcopy(model), reg_val=REG_TV_VAL)\n",
+    "denoiser_sup.train(vols_noisy, vol_orig, epochs=EPOCHS, tst_inds=tst_inds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "denoiser_n2v = ad.N2V(model=deepcopy(model), reg_val=REG_TV_VAL)\n",
+    "denoiser_n2v.train(vols_noisy, epochs=EPOCHS, tst_inds=tst_inds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "denoiser_n2n = ad.N2N(model=deepcopy(model), reg_val=REG_TV_VAL)\n",
+    "n2n_data = denoiser_n2n.prepare_data(vols_noisy)\n",
+    "denoiser_n2n.train(*n2n_data, epochs=EPOCHS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "denoiser_dip = ad.DIP(model=deepcopy(model), reg_val=REG_TV_VAL * 5)\n",
+    "dip_data = denoiser_dip.prepare_data(vols_noisy)\n",
+    "denoiser_dip.train(*dip_data, epochs=EPOCHS)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Getting the predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "den_sup = denoiser_sup.infer(vols_noisy).mean(0)\n",
+    "den_n2v = denoiser_n2v.infer(vols_noisy).mean(0)\n",
+    "den_n2n = denoiser_n2n.infer(n2n_data[0]).mean(0)\n",
+    "den_dip = denoiser_dip.infer(dip_data[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(2, 3, sharex=True, sharey=True)\n",
+    "axs[0, 0].imshow(vol_orig[central_slice])\n",
+    "axs[0, 0].set_title(\"Original image\")\n",
+    "axs[0, 1].imshow(vols_noisy[0][central_slice])\n",
+    "axs[0, 1].set_title(\"Noisy image\")\n",
+    "axs[0, 2].imshow(den_sup[central_slice])\n",
+    "axs[0, 2].set_title(\"Denoised supervised\")\n",
+    "axs[1, 0].imshow(den_n2v[central_slice])\n",
+    "axs[1, 0].set_title(\"Denoised N2V\")\n",
+    "axs[1, 1].imshow(den_n2n[central_slice])\n",
+    "axs[1, 1].set_title(\"Denoised N2N\")\n",
+    "axs[1, 2].imshow(den_dip[central_slice])\n",
+    "axs[1, 2].set_title(\"Denoised DIP\")\n",
+    "fig.tight_layout()\n",
+    "plt.show(block=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from corrct.processing.post import plot_frcs\n",
+    "from skimage.metrics import peak_signal_noise_ratio as psnr\n",
+    "from skimage.metrics import structural_similarity as ssim\n",
+    "\n",
+    "all_recs = [den_sup, den_n2v, den_n2n, den_dip]\n",
+    "all_labs = [\"Supervised\", \"Noise2Void\", \"Noise2Noise\", \"Deep Image Prior\"]\n",
+    "\n",
+    "data_range = vol_orig.max() - vol_orig.min()\n",
+    "print(\"PSNR:\")\n",
+    "for rec, lab in zip(all_recs, all_labs):\n",
+    "    print(f\"- {lab}: {psnr(vol_orig, rec, data_range=data_range):.3}\")\n",
+    "print(\"SSIM:\")\n",
+    "for rec, lab in zip(all_recs, all_labs):\n",
+    "    print(f\"- {lab}: {ssim(vol_orig, rec, data_range=data_range):.3}\")\n",
+    "\n",
+    "plot_frcs([(vol_orig.astype(np.float32), rec) for rec in all_recs], all_labs)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "tomography",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/autoden/algorithms/deep_image_prior.py
+++ b/src/autoden/algorithms/deep_image_prior.py
@@ -41,8 +41,8 @@ class DIP(Denoiser):
         algorithm. It also generates a mask array indicating the training pixels based
         on the provided ratio.
         """
-        if tgt.ndim < self.ndims:
-            raise ValueError(f"Target data should at least be of {self.ndims} dimensions, but its shape is {tgt.shape}")
+        if tgt.ndim < self.n_dims:
+            raise ValueError(f"Target data should at least be of {self.n_dims} dimensions, but its shape is {tgt.shape}")
 
         inp = np.random.normal(size=tgt.shape[-self.ndims :], scale=0.25).astype(tgt.dtype)
         mask_trn = get_random_pixel_mask(tgt.shape, mask_pixel_ratio=num_tst_ratio)

--- a/src/autoden/algorithms/deep_image_prior.py
+++ b/src/autoden/algorithms/deep_image_prior.py
@@ -43,8 +43,10 @@ class DIP(Denoiser):
         """
         if tgt.ndim < self.n_dims:
             raise ValueError(f"Target data should at least be of {self.n_dims} dimensions, but its shape is {tgt.shape}")
+        if tgt.ndim > self.n_dims:
+            tgt = tgt.mean(axis=tuple(np.arange(-tgt.ndim, -self.n_dims)))
 
-        inp = np.random.normal(size=tgt.shape[-self.ndims :], scale=0.25).astype(tgt.dtype)
+        inp = np.random.normal(size=tgt.shape[-self.n_dims :], scale=0.25).astype(tgt.dtype)
         mask_trn = get_random_pixel_mask(tgt.shape, mask_pixel_ratio=num_tst_ratio)
         return inp, tgt, mask_trn
 

--- a/src/autoden/algorithms/denoiser.py
+++ b/src/autoden/algorithms/denoiser.py
@@ -222,7 +222,7 @@ class Denoiser(ABC):
         self.verbose = verbose
 
     @property
-    def ndims(self) -> int:
+    def n_dims(self) -> int:
         return 2
 
     def _get_regularization(self) -> LossRegularizer | None:

--- a/src/autoden/algorithms/denoiser.py
+++ b/src/autoden/algorithms/denoiser.py
@@ -524,7 +524,7 @@ class Denoiser(ABC):
         self.model.eval()
         with pt.inference_mode():
             out_t: pt.Tensor = self.model(inp_t)
-            output = out_t.squeeze().to("cpu").numpy()
+            output = out_t.squeeze(dim=(0, 1)).to("cpu").numpy()
 
         # Rescale output
         if self.data_sb is not None:

--- a/src/autoden/algorithms/noise2noise.py
+++ b/src/autoden/algorithms/noise2noise.py
@@ -45,8 +45,8 @@ class N2N(Denoiser):
         This function generates input-target pairs based on the specified strategy. It also generates a mask array
         indicating the training pixels based on the provided ratio.
         """
-        if inp.ndim < self.ndims:
-            raise ValueError(f"Target data should at least be of {self.ndims} dimensions, but its shape is {inp.shape}")
+        if inp.ndim < self.n_dims:
+            raise ValueError(f"Target data should at least be of {self.n_dims} dimensions, but its shape is {inp.shape}")
 
         mask_trn = get_random_pixel_mask(inp.shape, mask_pixel_ratio=num_tst_ratio)
 

--- a/src/autoden/algorithms/noise2void.py
+++ b/src/autoden/algorithms/noise2void.py
@@ -165,13 +165,14 @@ class N2V(Denoiser):
             to_damage = np.where(mask > 0)
             to_check = np.where(mask > 1)
             inp_trn_damaged = pt.clone(inp_trn_t)
-            size_to_damage = inp_trn_damaged[..., *to_damage].shape
-            inp_trn_damaged[..., *to_damage] = pt.randn(size_to_damage, device=inp_trn_t.device, dtype=inp_trn_t.dtype)
+            # Once Python 3.10 is ditched, the parentheses can be ditched, and inp_trn_damaged[..., *to_damage] will be valid
+            size_to_damage = inp_trn_damaged[(..., *to_damage)].shape
+            inp_trn_damaged[(..., *to_damage)] = pt.randn(size_to_damage, device=inp_trn_t.device, dtype=inp_trn_t.dtype)
 
             optim.zero_grad()
             out_trn = self.model(inp_trn_damaged)
-            out_to_check = out_trn[..., *to_check].flatten()
-            ref_to_check = inp_trn_t[..., *to_check].flatten()
+            out_to_check = out_trn[(..., *to_check)].flatten()
+            ref_to_check = inp_trn_t[(..., *to_check)].flatten()
 
             loss_trn = loss_data_fn(out_to_check, ref_to_check)
             if regularizer is not None:

--- a/src/autoden/algorithms/noise2void.py
+++ b/src/autoden/algorithms/noise2void.py
@@ -14,7 +14,7 @@ from tqdm.auto import tqdm
 from autoden.losses import LossRegularizer
 from autoden.models.config import create_optimizer
 from autoden.models.param_utils import fix_invalid_gradient_values
-from autoden.algorithms.denoiser import Denoiser, compute_scaling_selfsupervised, _single_channel_imgs_to_tensor
+from autoden.algorithms.denoiser import Denoiser, compute_scaling_selfsupervised, data_to_tensor
 
 
 def _random_probe_mask(
@@ -154,26 +154,24 @@ class N2V(Denoiser):
         best_state = self.model.state_dict()
         best_optim = optim.state_dict()
 
-        inp_trn_t = _single_channel_imgs_to_tensor(inp_trn, device=self.device)
-        inp_tst_t = _single_channel_imgs_to_tensor(inp_tst, device=self.device)
+        inp_trn_t = data_to_tensor(inp_trn, device=self.device, n_dims=self.n_dims)
+        inp_tst_t = data_to_tensor(inp_tst, device=self.device, n_dims=self.n_dims)
 
         for epoch in tqdm(range(epochs), desc=f"Training {algo.upper()}"):
             # Train
             self.model.train()
 
-            mask = _random_probe_mask(inp_trn_t.shape[-2:], mask_shape, ratio_blind_spots=ratio_blind_spot)
+            mask = _random_probe_mask(inp_trn_t.shape[-self.n_dims :], mask_shape, ratio_blind_spots=ratio_blind_spot)
             to_damage = np.where(mask > 0)
             to_check = np.where(mask > 1)
             inp_trn_damaged = pt.clone(inp_trn_t)
-            size_to_damage = inp_trn_damaged[..., to_damage[0], to_damage[1]].shape
-            inp_trn_damaged[..., to_damage[0], to_damage[1]] = pt.randn(
-                size_to_damage, device=inp_trn_t.device, dtype=inp_trn_t.dtype
-            )
+            size_to_damage = inp_trn_damaged[..., *to_damage].shape
+            inp_trn_damaged[..., *to_damage] = pt.randn(size_to_damage, device=inp_trn_t.device, dtype=inp_trn_t.dtype)
 
             optim.zero_grad()
             out_trn = self.model(inp_trn_damaged)
-            out_to_check = out_trn[..., to_check[0], to_check[1]].flatten()
-            ref_to_check = inp_trn_t[..., to_check[0], to_check[1]].flatten()
+            out_to_check = out_trn[..., *to_check].flatten()
+            ref_to_check = inp_trn_t[..., *to_check].flatten()
 
             loss_trn = loss_data_fn(out_to_check, ref_to_check)
             if regularizer is not None:

--- a/src/autoden/losses.py
+++ b/src/autoden/losses.py
@@ -43,19 +43,19 @@ class LossTV(LossRegularizer):
         reduce=None,
         reduction: str = "mean",
         isotropic: bool = True,
-        ndims: int = 2,
+        n_dims: int = 2,
     ) -> None:
         super().__init__(size_average, reduce, reduction)
         self.lambda_val = lambda_val
         self.isotropic = isotropic
-        self.ndims = ndims
+        self.n_dims = n_dims
 
     def forward(self, img: pt.Tensor) -> pt.Tensor:
         """Compute total variation statistics on current batch."""
-        _check_input_tensor(img, self.ndims)
-        axes = list(range(-(self.ndims + 1), 0))
+        _check_input_tensor(img, self.n_dims)
+        axes = list(range(-(self.n_dims + 1), 0))
 
-        diffs = [_differentiate(img, dim=dim, position="post") for dim in range(-self.ndims, 0)]
+        diffs = [_differentiate(img, dim=dim, position="post") for dim in range(-self.n_dims, 0)]
         diffs = pt.stack(diffs, dim=0)
 
         if self.isotropic:
@@ -73,11 +73,11 @@ class LossTGV(LossTV):
 
     def forward(self, img: pt.Tensor) -> pt.Tensor:
         """Compute total variation statistics on current batch."""
-        _check_input_tensor(img, self.ndims)
-        axes = list(range(-(self.ndims + 1), 0))
+        _check_input_tensor(img, self.n_dims)
+        axes = list(range(-(self.n_dims + 1), 0))
 
-        diffs = [_differentiate(img, dim=dim, position="post") for dim in range(-self.ndims, 0)]
-        diffdiffs = [_differentiate(d, dim=dim, position="pre") for dim in range(-self.ndims, 0) for d in diffs]
+        diffs = [_differentiate(img, dim=dim, position="post") for dim in range(-self.n_dims, 0)]
+        diffdiffs = [_differentiate(d, dim=dim, position="pre") for dim in range(-self.n_dims, 0) for d in diffs]
 
         if self.isotropic:
             tv_val = pt.sqrt(pt.stack([pt.pow(d, 2) for d in diffs], dim=0).sum(dim=0))
@@ -204,7 +204,7 @@ class LossSWTN(LossRegularizer):
         reduction: str = "mean",
         isotropic: bool = True,
         levels: int = 2,
-        ndims: int = 2,
+        n_dims: int = 2,
         min_approx: bool = False,
     ) -> None:
         super().__init__(size_average, reduce, reduction)
@@ -213,13 +213,13 @@ class LossSWTN(LossRegularizer):
         self.lambda_val = lambda_val
         self.isotropic = isotropic
         self.levels = levels
-        self.ndims = ndims
+        self.n_dims = n_dims
         self.min_approx = min_approx
 
     def forward(self, img: pt.Tensor) -> pt.Tensor:
         """Compute wavelet decomposition on current batch."""
-        _check_input_tensor(img, self.ndims)
-        axes = list(range(-(self.ndims + 1), 0))
+        _check_input_tensor(img, self.n_dims)
+        axes = list(range(-(self.n_dims + 1), 0))
 
         coeffs = swt_nd(img, wl_dec_lo=self.wl_dec_lo, wl_dec_hi=self.wl_dec_hi, level=self.levels, normalize="scale")
 

--- a/src/autoden/models/config.py
+++ b/src/autoden/models/config.py
@@ -39,11 +39,13 @@ class NetworkParams(ABC):
     n_channels_in: int
     n_channels_out: int
     n_features: int
+    n_dims: int
 
-    def __init__(self, n_features: int, n_channels_in: int = 1, n_channels_out: int = 1) -> None:
+    def __init__(self, n_features: int, n_channels_in: int = 1, n_channels_out: int = 1, n_dims: int = 2) -> None:
         self.n_channels_in = n_channels_in
         self.n_channels_out = n_channels_out
         self.n_features = n_features
+        self.n_dims = n_dims
 
     def __repr__(self) -> str:
         """Produce the string representation of the object.
@@ -83,6 +85,7 @@ class NetworkParamsMSD(NetworkParams):
         n_channels_out: int = 1,
         n_layers: int = 12,
         n_features: int = 1,
+        n_dims: int = 2,
         dilations: Sequence[int] | NDArray[np.integer] = np.arange(1, 4),
         use_dilations: bool = True,
     ) -> None:
@@ -98,12 +101,14 @@ class NetworkParamsMSD(NetworkParams):
             Number of layers in the network, by default 12.
         n_features : int, optional
             Number of features, by default 1.
+        n_dims : int, optional
+            Number of dimensions of the signals/convolutions, by default 2.
         dilations : Sequence[int] | NDArray[np.integer], optional
             Dilation values for the network, by default np.arange(1, 4).
         use_dilations : bool, optional
             Whether to use dilations in the network, by default True.
         """
-        super().__init__(n_features=n_features, n_channels_in=n_channels_in, n_channels_out=n_channels_out)
+        super().__init__(n_features=n_features, n_channels_in=n_channels_in, n_channels_out=n_channels_out, n_dims=n_dims)
         self.n_layers = n_layers
         self.dilations = dilations
         self.use_dilations = use_dilations
@@ -147,6 +152,7 @@ class NetworkParamsUNet(NetworkParams):
         n_levels: int = DEFAULT_LEVELS,
         n_features: int = DEFAULT_FEATURES,
         n_channels_skip: int | None = None,
+        n_dims: int = 2,
         bilinear: bool = True,
         pad_mode: str = "replicate",
     ) -> None:
@@ -164,12 +170,14 @@ class NetworkParamsUNet(NetworkParams):
             Number of features in the UNet. Default is 32.
         n_channels_skip : int, optional
             Number of skip connections channels. Default is None.
+        n_dims : int, optional
+            Number of dimensions of the signals/convolutions, by default 2.
         bilinear : bool, optional
             Whether to use bilinear interpolation. Default is True.
         pad_mode : str, optional
             Padding mode for convolutional layers. Default is "replicate".
         """
-        super().__init__(n_features=n_features, n_channels_in=n_channels_in, n_channels_out=n_channels_out)
+        super().__init__(n_features=n_features, n_channels_in=n_channels_in, n_channels_out=n_channels_out, n_dims=n_dims)
         self.n_levels = n_levels
         self.n_channels_skip = n_channels_skip
         self.bilinear = bilinear
@@ -194,6 +202,7 @@ class NetworkParamsUNet(NetworkParams):
             n_features=self.n_features,
             n_levels=self.n_levels,
             n_channels_skip=self.n_channels_skip,
+            n_dims=self.n_dims,
             bilinear=self.bilinear,
             pad_mode=self.pad_mode,
             device=device,
@@ -211,6 +220,7 @@ class NetworkParamsDnCNN(NetworkParams):
         n_channels_out: int = 1,
         n_layers: int = 20,
         n_features: int = 64,
+        n_dims: int = 2,
         kernel_size: int = 3,
         pad_mode: str = "replicate",
     ) -> None:
@@ -226,12 +236,14 @@ class NetworkParamsDnCNN(NetworkParams):
             Number of layers. Default is 20.
         n_features : int, optional
             Number of features. Default is 64.
+        n_dims : int, optional
+            Number of dimensions of the signals/convolutions, by default 2.
         kernel_size : int, optional
             Size of the convolutional kernel. Default is 3.
         pad_mode : str, optional
             Padding mode for the convolutional layers. Default is "replicate".
         """
-        super().__init__(n_features=n_features, n_channels_in=n_channels_in, n_channels_out=n_channels_out)
+        super().__init__(n_features=n_features, n_channels_in=n_channels_in, n_channels_out=n_channels_out, n_dims=n_dims)
         self.n_layers = n_layers
         self.kernel_size = kernel_size
         self.pad_mode = pad_mode
@@ -254,6 +266,7 @@ class NetworkParamsDnCNN(NetworkParams):
             n_channels_out=self.n_channels_out,
             n_layers=self.n_layers,
             n_features=self.n_features,
+            n_dims=self.n_dims,
             kernel_size=self.kernel_size,
             pad_mode=self.pad_mode,
             device=device,
@@ -271,6 +284,7 @@ class NetworkParamsResnet(NetworkParams):
         n_channels_out: int = 1,
         n_layers: int = 10,
         n_features: int = 24,
+        n_dims: int = 2,
         kernel_size: int = 3,
         pad_mode: str = "replicate",
     ) -> None:
@@ -286,12 +300,14 @@ class NetworkParamsResnet(NetworkParams):
             Number of layers. Default is 10.
         n_features : int, optional
             Number of features. Default is 24.
+        n_dims : int, optional
+            Number of dimensions of the signals/convolutions, by default 2.
         kernel_size : int, optional
             Size of the convolutional kernel. Default is 3.
         pad_mode : str, optional
             Padding mode for the convolutional layers. Default is "replicate".
         """
-        super().__init__(n_features=n_features, n_channels_in=n_channels_in, n_channels_out=n_channels_out)
+        super().__init__(n_features=n_features, n_channels_in=n_channels_in, n_channels_out=n_channels_out, n_dims=n_dims)
         self.n_layers = n_layers
         self.kernel_size = kernel_size
         self.pad_mode = pad_mode
@@ -314,6 +330,7 @@ class NetworkParamsResnet(NetworkParams):
             n_channels_out=self.n_channels_out,
             n_layers=self.n_layers,
             n_features=self.n_features,
+            n_dims=self.n_dims,
             kernel_size=self.kernel_size,
             pad_mode=self.pad_mode,
             device=device,
@@ -359,6 +376,7 @@ def create_network(
     - "msd": Multi-Scale Dense Network.
     - "unet": U-Net.
     - "dncnn": Denoising Convolutional Neural Network.
+    - "resnet": Residual Neural Network.
 
     Examples
     --------

--- a/src/autoden/models/dncnn.py
+++ b/src/autoden/models/dncnn.py
@@ -9,15 +9,15 @@ class ConvBlock(nn.Sequential):
     """Convolution block: conv => BN => act."""
 
     def __init__(
-        self, in_ch: int, out_ch: int, kernel_size: int, ndim: int = 2, pad_mode: str = "replicate", last_block: bool = False
+        self, in_ch: int, out_ch: int, kernel_size: int, n_dims: int = 2, pad_mode: str = "replicate", last_block: bool = False
     ):
         pad_size = (kernel_size - 1) // 2
         if last_block:
             post_conv = []
         else:
-            post_conv = [NDBatchNorm[ndim](out_ch), nn.LeakyReLU(0.2, inplace=True)]
+            post_conv = [NDBatchNorm[n_dims](out_ch), nn.LeakyReLU(0.2, inplace=True)]
         super().__init__(
-            NDConv[ndim](in_ch, out_ch, kernel_size=kernel_size, padding=pad_size, padding_mode=pad_mode, bias=False),
+            NDConv[n_dims](in_ch, out_ch, kernel_size=kernel_size, padding=pad_size, padding_mode=pad_mode, bias=False),
             *post_conv,
         )
 
@@ -35,10 +35,10 @@ class DnCNN(nn.Sequential):
         n_channels_out: int,
         n_layers: int = 20,
         n_features: int = 32,
+        n_dims: int = 2,
         kernel_size: int = 3,
         pad_mode: str = "replicate",
         device: str = "cuda" if pt.cuda.is_available() else "cpu",
-        ndim: int = 2,
     ):
         init_params = locals()
         del init_params["self"]
@@ -57,7 +57,7 @@ class DnCNN(nn.Sequential):
                 n_channels_in if i_l == 0 else n_features,
                 n_channels_out if i_l == (n_layers - 1) else n_features,
                 kernel_size=kernel_size,
-                ndim=ndim,
+                n_dims=n_dims,
                 pad_mode=pad_mode,
                 last_block=(i_l == (n_layers - 1)),
             )

--- a/src/autoden/models/msd.py
+++ b/src/autoden/models/msd.py
@@ -21,10 +21,10 @@ def _get_alignment_padding(shape: tuple[int, ...], n_levels: int = 1, kernel_siz
 class DilatedConvBlock(nn.Sequential):
     """Dilated convolution block (dilated_conv => BN => ReLU)."""
 
-    def __init__(self, in_ch: int, out_ch: int, dilation: int = 1, pad_mode: str = "replicate", ndim: int = 2) -> None:
+    def __init__(self, in_ch: int, out_ch: int, dilation: int = 1, pad_mode: str = "replicate", n_dims: int = 2) -> None:
         super().__init__(
-            NDConv[ndim](in_ch, out_ch, 3, padding=dilation, dilation=dilation, padding_mode=pad_mode),
-            NDBatchNorm[ndim](out_ch),
+            NDConv[n_dims](in_ch, out_ch, 3, padding=dilation, dilation=dilation, padding_mode=pad_mode),
+            NDBatchNorm[n_dims](out_ch),
             nn.LeakyReLU(0.2, inplace=True),
         )
 
@@ -32,28 +32,32 @@ class DilatedConvBlock(nn.Sequential):
 class SamplingConvBlock(nn.Sequential):
     """Down-sampling convolution module (down-samp => conv => BN => ReLU => up-samp)."""
 
-    def __init__(self, in_ch: int, out_ch: int, samp_factor: int = 1, ndim: int = 2) -> None:
+    def __init__(self, in_ch: int, out_ch: int, samp_factor: int = 1, n_dims: int = 2) -> None:
         if samp_factor > 1:
-            pre = [NDPool[ndim](samp_factor)]
-            post = [nn.Upsample(scale_factor=samp_factor, mode=NDUpsampling[ndim], align_corners=True)]
+            pre = [NDPool[n_dims](samp_factor)]
+            post = [nn.Upsample(scale_factor=samp_factor, mode=NDUpsampling[n_dims], align_corners=True)]
         else:
             pre = post = []
         super().__init__(
-            *pre, NDConv[ndim](in_ch, out_ch, 3, padding=1), NDBatchNorm[ndim](out_ch), nn.LeakyReLU(0.2, inplace=True), *post
+            *pre,
+            NDConv[n_dims](in_ch, out_ch, 3, padding=1),
+            NDBatchNorm[n_dims](out_ch),
+            nn.LeakyReLU(0.2, inplace=True),
+            *post,
         )
 
 
 class MSDSampBlock(nn.Module):
     """MS-D Block containing the sequence of dilated convolutional layers."""
 
-    def __init__(self, n_channels_in: int, n_features: int, n_layers: int, dilations: Sequence[int], ndim: int = 2) -> None:
+    def __init__(self, n_channels_in: int, n_features: int, n_layers: int, dilations: Sequence[int], n_dims: int = 2) -> None:
         super().__init__()
         self.n_features = n_features
         self.n_layers = n_layers
         self.dilations = dilations
-        self.ndim = ndim
+        self.n_dims = n_dims
         convs = [
-            SamplingConvBlock(n_channels_in + n_features * ii, n_features, samp_factor=self._layer_sampling(ii), ndim=ndim)
+            SamplingConvBlock(n_channels_in + n_features * ii, n_features, samp_factor=self._layer_sampling(ii), n_dims=n_dims)
             for ii in range(n_layers)
         ]
         self.convs = nn.ModuleList(convs)
@@ -64,7 +68,7 @@ class MSDSampBlock(nn.Module):
 
     def forward(self, x: pt.Tensor) -> pt.Tensor:
         padding = _get_alignment_padding(x.shape[2:], n_levels=max(self.dilations) - 1, kernel_size=3)
-        pad_input = NDPadding[self.ndim](padding)
+        pad_input = NDPadding[self.n_dims](padding)
 
         latent = [pad_input(x)]
         for conv in self.convs:
@@ -78,14 +82,14 @@ class MSDSampBlock(nn.Module):
 class MSDDilBlock(nn.Module):
     """MS-D Block containing the sequence of dilated convolutional layers."""
 
-    def __init__(self, n_channels_in: int, n_features: int, n_layers: int, dilations: Sequence[int], ndim: int = 2) -> None:
+    def __init__(self, n_channels_in: int, n_features: int, n_layers: int, dilations: Sequence[int], n_dims: int = 2) -> None:
         super().__init__()
         self.n_features = n_features
         self.n_layers = n_layers
         self.dilations = dilations
-        self.ndim = ndim
+        self.n_dims = n_dims
         convs = [
-            DilatedConvBlock(n_channels_in + n_features * ii, n_features, dilation=self._layer_dilation(ii), ndim=ndim)
+            DilatedConvBlock(n_channels_in + n_features * ii, n_features, dilation=self._layer_dilation(ii), n_dims=n_dims)
             for ii in range(n_layers)
         ]
         self.convs = nn.ModuleList(convs)
@@ -110,10 +114,10 @@ class MSDnet(nn.Module):
         n_channels_out: int = 1,
         n_layers: int = 12,
         n_features: int = 1,
+        n_dims: int = 2,
         dilations: Sequence[int] = [1, 2, 3, 4],
         device: str = "cuda" if pt.cuda.is_available() else "cpu",
         use_dilations: bool = True,
-        ndim: int = 2,
     ) -> None:
         init_params = locals()
         del init_params["self"]
@@ -124,10 +128,10 @@ class MSDnet(nn.Module):
         self.device = device
 
         if use_dilations:
-            self.msd_block = MSDDilBlock(n_channels_in, n_features, n_layers, dilations, ndim=ndim)
+            self.msd_block = MSDDilBlock(n_channels_in, n_features, n_layers, dilations, n_dims=n_dims)
         else:
-            self.msd_block = MSDSampBlock(n_channels_in, n_features, n_layers, dilations, ndim=ndim)
-        self.outc = NDConv[ndim](n_channels_in + n_features * n_layers, n_channels_out, kernel_size=1)
+            self.msd_block = MSDSampBlock(n_channels_in, n_features, n_layers, dilations, n_dims=n_dims)
+        self.outc = NDConv[n_dims](n_channels_in + n_features * n_layers, n_channels_out, kernel_size=1)
 
         self.to(self.device)
 

--- a/src/autoden/models/resnet.py
+++ b/src/autoden/models/resnet.py
@@ -13,7 +13,7 @@ class ResBlock(nn.Module):
         in_ch: int,
         out_ch: int,
         kernel_size: int,
-        ndim: int = 2,
+        n_dims: int = 2,
         pad_mode: str = "replicate",
         last_block: bool = False,
         bias: bool = True,
@@ -22,14 +22,14 @@ class ResBlock(nn.Module):
         pad_size = (kernel_size - 1) // 2
         self.main_seq = nn.ModuleList(
             [
-                NDConv[ndim](in_ch, out_ch, kernel_size=kernel_size, padding=pad_size, padding_mode=pad_mode, bias=bias),
-                NDBatchNorm[ndim](out_ch),
+                NDConv[n_dims](in_ch, out_ch, kernel_size=kernel_size, padding=pad_size, padding_mode=pad_mode, bias=bias),
+                NDBatchNorm[n_dims](out_ch),
                 nn.LeakyReLU(0.2, inplace=True),
-                NDConv[ndim](out_ch, out_ch, kernel_size=kernel_size, padding=pad_size, padding_mode=pad_mode, bias=bias),
-                NDBatchNorm[ndim](out_ch),
+                NDConv[n_dims](out_ch, out_ch, kernel_size=kernel_size, padding=pad_size, padding_mode=pad_mode, bias=bias),
+                NDBatchNorm[n_dims](out_ch),
             ]
         )
-        self.scale_inp = NDConv[ndim](in_ch, out_ch, kernel_size=1, bias=bias) if in_ch != out_ch else None
+        self.scale_inp = NDConv[n_dims](in_ch, out_ch, kernel_size=1, bias=bias) if in_ch != out_ch else None
         self.post_res = nn.LeakyReLU(0.2, inplace=True) if not last_block else None
 
     def forward(self, inp: pt.Tensor) -> pt.Tensor:
@@ -53,10 +53,10 @@ class Resnet(nn.Sequential):
         n_channels_out: int,
         n_layers: int = 10,
         n_features: int = 32,
+        n_dims: int = 2,
         kernel_size: int = 3,
         pad_mode: str = "replicate",
         device: str = "cuda" if pt.cuda.is_available() else "cpu",
-        ndim: int = 2,
     ):
         init_params = locals()
         del init_params["self"]
@@ -67,7 +67,7 @@ class Resnet(nn.Sequential):
                 n_channels_in if i_l == 0 else n_features,
                 n_channels_out if i_l == (n_layers - 1) else n_features,
                 kernel_size=kernel_size,
-                ndim=ndim,
+                n_dims=n_dims,
                 pad_mode=pad_mode,
                 last_block=(i_l == (n_layers - 1)),
             )

--- a/tests/algorithms/mock_model.py
+++ b/tests/algorithms/mock_model.py
@@ -19,6 +19,7 @@ class MockModel(nn.Module):
 
 
 class MockSerializableModel3D(MockModel):
+    """Mock serializable model that returns the input volumes it receives."""
 
     def __init__(self):
         super().__init__()

--- a/tests/algorithms/mock_model.py
+++ b/tests/algorithms/mock_model.py
@@ -16,3 +16,10 @@ class MockModel(nn.Module):
     def forward(self, x):
         """Return the input images."""
         return self.param * x
+
+
+class MockSerializableModel3D(MockModel):
+
+    def __init__(self):
+        super().__init__()
+        self.init_params = dict(n_dims=3)

--- a/tests/algorithms/test_deep_image_prior.py
+++ b/tests/algorithms/test_deep_image_prior.py
@@ -18,7 +18,7 @@ def test_dip_prepare_data(dip_algo):
     """Test the prepare_data method of the DIP class."""
     tgt = np.random.rand(10, 10, 10)
     inp, tgt, mask_trn = dip_algo.prepare_data(tgt)
-    assert inp.shape == tgt.shape[-dip_algo.ndims :]
+    assert inp.shape == tgt.shape[-dip_algo.n_dims :]
     assert mask_trn.shape == tgt.shape
 
 

--- a/tests/models/test_dncnn.py
+++ b/tests/models/test_dncnn.py
@@ -4,99 +4,99 @@ import torch.nn as nn
 from autoden.models.dncnn import ConvBlock, DnCNN
 
 
-@pytest.mark.parametrize("ndim", [1, 2, 3])
-def test_conv_block_initialization(ndim):
+@pytest.mark.parametrize("n_dims", [1, 2, 3])
+def test_conv_block_initialization(n_dims):
     """
     Test the initialization of ConvBlock.
     Ensures that the ConvBlock is correctly initialized with the expected layers.
     """
-    conv_block = ConvBlock(in_ch=3, out_ch=32, kernel_size=3, ndim=ndim)
+    conv_block = ConvBlock(in_ch=3, out_ch=32, kernel_size=3, n_dims=n_dims)
     assert isinstance(conv_block, nn.Sequential)
     assert len(conv_block) == 3  # Conv, BatchNorm, LeakyReLU
 
-    conv_block_last = ConvBlock(in_ch=32, out_ch=3, kernel_size=3, ndim=ndim, last_block=True)
+    conv_block_last = ConvBlock(in_ch=32, out_ch=3, kernel_size=3, n_dims=n_dims, last_block=True)
     assert isinstance(conv_block_last, nn.Sequential)
     assert len(conv_block_last) == 1  # Only Conv
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
-def test_conv_block_forward_pass(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
+def test_conv_block_forward_pass(n_dims, shape):
     """
     Test the forward pass of ConvBlock.
     Ensures that the output tensor has the expected shape.
     """
-    conv_block = ConvBlock(in_ch=3, out_ch=32, kernel_size=3, ndim=ndim)
+    conv_block = ConvBlock(in_ch=3, out_ch=32, kernel_size=3, n_dims=n_dims)
     input_tensor = torch.randn(*shape)
     output_tensor = conv_block(input_tensor)
     assert output_tensor.shape == (1, 32, *shape[2:])
 
-    conv_block_last = ConvBlock(in_ch=32, out_ch=3, kernel_size=3, ndim=ndim, last_block=True)
+    conv_block_last = ConvBlock(in_ch=32, out_ch=3, kernel_size=3, n_dims=n_dims, last_block=True)
     input_tensor = torch.randn(1, 32, *shape[2:])
     output_tensor = conv_block_last(input_tensor)
     assert output_tensor.shape == (1, 3, *shape[2:])
 
 
-@pytest.mark.parametrize("ndim", [1, 2, 3])
-def test_dncnn_initialization(ndim):
+@pytest.mark.parametrize("n_dims", [1, 2, 3])
+def test_dncnn_initialization(n_dims):
     """
     Test the initialization of DnCNN.
     Ensures that the DnCNN is correctly initialized with the expected number of layers.
     """
-    dncnn = DnCNN(n_channels_in=3, n_channels_out=3, ndim=ndim)
+    dncnn = DnCNN(n_channels_in=3, n_channels_out=3, n_dims=n_dims)
     assert isinstance(dncnn, nn.Sequential)
     assert len(dncnn) == 20  # Default number of layers is 20
 
-    dncnn_custom = DnCNN(n_channels_in=3, n_channels_out=3, n_layers=10, n_features=64, kernel_size=5, ndim=ndim)
+    dncnn_custom = DnCNN(n_channels_in=3, n_channels_out=3, n_layers=10, n_features=64, kernel_size=5, n_dims=n_dims)
     assert isinstance(dncnn_custom, nn.Sequential)
     assert len(dncnn_custom) == 10  # Custom number of layers is 10
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
-def test_dncnn_forward_pass(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
+def test_dncnn_forward_pass(n_dims, shape):
     """
     Test the forward pass of DnCNN.
     Ensures that the output tensor has the expected shape.
     """
-    dncnn = DnCNN(n_channels_in=3, n_channels_out=3, ndim=ndim)
+    dncnn = DnCNN(n_channels_in=3, n_channels_out=3, n_dims=n_dims)
     input_tensor = torch.randn(*shape, device=dncnn.device)
     output_tensor = dncnn(input_tensor)
     assert output_tensor.shape == (1, 3, *shape[2:])
 
 
-@pytest.mark.parametrize("ndim", [1, 2, 3])
-def test_dncnn_device_handling(ndim):
+@pytest.mark.parametrize("n_dims", [1, 2, 3])
+def test_dncnn_device_handling(n_dims):
     """
     Test the device handling of DnCNN.
     Ensures that the DnCNN is correctly assigned to the specified device.
     """
-    dncnn = DnCNN(n_channels_in=3, n_channels_out=3, ndim=ndim, device='cpu')
+    dncnn = DnCNN(n_channels_in=3, n_channels_out=3, n_dims=n_dims, device='cpu')
     assert dncnn.device == 'cpu'
 
     if torch.cuda.is_available():
-        dncnn = DnCNN(n_channels_in=3, n_channels_out=3, ndim=ndim, device='cuda')
+        dncnn = DnCNN(n_channels_in=3, n_channels_out=3, n_dims=n_dims, device='cuda')
         assert dncnn.device == 'cuda'
 
 
-@pytest.mark.parametrize("ndim", [1, 2, 3])
-def test_dncnn_invalid_device(ndim):
+@pytest.mark.parametrize("n_dims", [1, 2, 3])
+def test_dncnn_invalid_device(n_dims):
     """
     Test the handling of an invalid device for DnCNN.
     Ensures that a ValueError is raised when an invalid device is specified.
     """
     with pytest.raises(RuntimeError):
-        DnCNN(n_channels_in=3, n_channels_out=3, ndim=ndim, device='invalid_device')
+        DnCNN(n_channels_in=3, n_channels_out=3, n_dims=n_dims, device='invalid_device')
 
 
 @pytest.mark.parametrize(
-    "ndim,inv_shape",
+    "n_dims,inv_shape",
     [(1, (1, 3, 64, 64)), (2, (1, 3, 64, 64, 64)), (3, (1, 3, 64, 64))],  # Invalid for 1D  # Invalid for 2D  # Invalid for 3D
 )
-def test_dncnn_invalid_input_shape(ndim, inv_shape):
+def test_dncnn_invalid_input_shape(n_dims, inv_shape):
     """
     Test the handling of an invalid input shape for DnCNN.
     Ensures that a RuntimeError is raised when the input tensor has an invalid shape.
     """
-    dncnn = DnCNN(n_channels_in=3, n_channels_out=3, ndim=ndim)
+    dncnn = DnCNN(n_channels_in=3, n_channels_out=3, n_dims=n_dims)
     input_tensor = torch.randn(*inv_shape)
     with pytest.raises(RuntimeError):
         dncnn(input_tensor)

--- a/tests/models/test_msd.py
+++ b/tests/models/test_msd.py
@@ -3,109 +3,109 @@ import torch as pt
 from autoden.models.msd import MSDnet, DilatedConvBlock, SamplingConvBlock, MSDSampBlock, MSDDilBlock
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
-def test_dilated_conv_block(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
+def test_dilated_conv_block(n_dims, shape):
     """
     Test the DilatedConvBlock to ensure it outputs the correct shape.
 
     The input tensor has shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32), and the output tensor should have shape (1, 16, 64), (1, 16, 64, 64), or (1, 16, 16, 32, 32).
     """
-    block = DilatedConvBlock(1, 16, dilation=1, ndim=ndim)
+    block = DilatedConvBlock(1, 16, dilation=1, n_dims=n_dims)
     input_tensor = pt.randn(*shape)
     output_tensor = block(input_tensor)
     assert output_tensor.shape == (1, 16, *shape[2:])
 
-    block = DilatedConvBlock(1, 16, dilation=2, ndim=ndim)
+    block = DilatedConvBlock(1, 16, dilation=2, n_dims=n_dims)
     input_tensor = pt.randn(*shape)
     output_tensor = block(input_tensor)
     assert output_tensor.shape == (1, 16, *shape[2:])
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
-def test_sampling_conv_block(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
+def test_sampling_conv_block(n_dims, shape):
     """
     Test the SamplingConvBlock to ensure it outputs the correct shape.
 
     The input tensor has shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32), and the output tensor should have shape (1, 16, 32), (1, 16, 32, 32), or (1, 16, 8, 16, 16) due to down-sampling.
     """
-    block = SamplingConvBlock(1, 16, samp_factor=2, ndim=ndim)
+    block = SamplingConvBlock(1, 16, samp_factor=2, n_dims=n_dims)
     input_tensor = pt.randn(*shape)
     output_tensor = block(input_tensor)
     assert output_tensor.shape == (1, 16, *shape[2:])
 
-    block = SamplingConvBlock(1, 16, samp_factor=4, ndim=ndim)
+    block = SamplingConvBlock(1, 16, samp_factor=4, n_dims=n_dims)
     input_tensor = pt.randn(*shape)
     output_tensor = block(input_tensor)
     assert output_tensor.shape == (1, 16, *shape[2:])
 
-    block = SamplingConvBlock(1, 16, samp_factor=3, ndim=ndim)
+    block = SamplingConvBlock(1, 16, samp_factor=3, n_dims=n_dims)
     input_tensor = pt.randn(*shape)
     output_tensor = block(input_tensor)
     assert output_tensor.shape != (1, 16, *shape[2:])
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
-def test_msd_samp_block(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
+def test_msd_samp_block(n_dims, shape):
     """
     Test the MSDSampBlock to ensure it outputs the correct shape.
 
     The input tensor has shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32), and the output tensor should have shape (1, 16 * 3 + 1, 64), (1, 16 * 3 + 1, 64, 64), or (1, 16 * 3 + 1, 16, 32, 32).
     """
-    block = MSDSampBlock(1, 16, 3, [1, 2, 3], ndim=ndim)
+    block = MSDSampBlock(1, 16, 3, [1, 2, 3], n_dims=n_dims)
     input_tensor = pt.randn(*shape)
     output_tensor = block(input_tensor)
     assert output_tensor.shape == (1, 16 * 3 + 1, *shape[2:])
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
-def test_msd_dil_block(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
+def test_msd_dil_block(n_dims, shape):
     """
     Test the MSDDilBlock to ensure it outputs the correct shape.
 
     The input tensor has shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32), and the output tensor should have shape (1, 16 * 3 + 1, 64), (1, 16 * 3 + 1, 64, 64), or (1, 16 * 3 + 1, 16, 32, 32).
     """
-    block = MSDDilBlock(1, 16, 3, [1, 2, 3], ndim=ndim)
+    block = MSDDilBlock(1, 16, 3, [1, 2, 3], n_dims=n_dims)
     input_tensor = pt.randn(*shape)
     output_tensor = block(input_tensor)
     assert output_tensor.shape == (1, 16 * 3 + 1, *shape[2:])
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
-def test_msdnet_forward(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
+def test_msdnet_forward(n_dims, shape):
     """
     Test the MSDnet forward pass to ensure it outputs the correct shape.
 
     The input tensor has shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32), and the output tensor should have shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32).
     """
-    model = MSDnet(n_channels_in=1, n_channels_out=1, n_layers=3, n_features=16, use_dilations=True, ndim=ndim)
+    model = MSDnet(n_channels_in=1, n_channels_out=1, n_layers=3, n_features=16, use_dilations=True, n_dims=n_dims)
     input_tensor = pt.randn(*shape, device=model.device)
     output_tensor = model(input_tensor)
     assert output_tensor.shape == (1, 1, *shape[2:])
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
-def test_msdnet_forward_with_latent(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
+def test_msdnet_forward_with_latent(n_dims, shape):
     """
     Test the MSDnet forward pass with the return_latent flag to ensure it outputs both the correct output and latent tensors.
 
     The input tensor has shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32), and the output tensor should have shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32).
     The latent tensor should have shape (1, 16 * 3 + 1, 64), (1, 16 * 3 + 1, 64, 64), or (1, 16 * 3 + 1, 16, 32, 32).
     """
-    model = MSDnet(n_channels_in=1, n_channels_out=1, n_layers=3, n_features=16, use_dilations=True, ndim=ndim)
+    model = MSDnet(n_channels_in=1, n_channels_out=1, n_layers=3, n_features=16, use_dilations=True, n_dims=n_dims)
     input_tensor = pt.randn(*shape, device=model.device)
     output_tensor, latent_tensor = model(input_tensor, return_latent=True)
     assert output_tensor.shape == (1, 1, *shape[2:])
     assert latent_tensor.shape == (1, 16 * 3 + 1, *shape[2:])
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
-def test_msdnet_use_sampling(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 1, 64)), (2, (1, 1, 64, 64)), (3, (1, 1, 16, 32, 32))])
+def test_msdnet_use_sampling(n_dims, shape):
     """
     Test the MSDnet with the use_dilations flag set to False to ensure it outputs the correct shape.
 
     The input tensor has shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32), and the output tensor should have shape (1, 1, 64), (1, 1, 64, 64), or (1, 1, 16, 32, 32).
     """
-    model = MSDnet(n_channels_in=1, n_channels_out=1, n_layers=3, n_features=16, use_dilations=False, ndim=ndim)
+    model = MSDnet(n_channels_in=1, n_channels_out=1, n_layers=3, n_features=16, use_dilations=False, n_dims=n_dims)
     input_tensor = pt.randn(*shape, device=model.device)
     output_tensor = model(input_tensor)
     assert output_tensor.shape == (1, 1, *shape[2:])

--- a/tests/models/test_resnet.py
+++ b/tests/models/test_resnet.py
@@ -3,8 +3,8 @@ import torch as pt
 from src.autoden.models.resnet import ResBlock, Resnet
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (2, 3, 32)), (2, (2, 3, 32, 32)), (3, (2, 3, 8, 16, 16))])
-def test_resblock_forward(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (2, 3, 32)), (2, (2, 3, 32, 32)), (3, (2, 3, 8, 16, 16))])
+def test_resblock_forward(n_dims, shape):
     """Test ResBlock forward pass."""
     batch_size, in_ch, *spatial_dims = shape
     out_ch = 64
@@ -12,14 +12,14 @@ def test_resblock_forward(ndim, shape):
 
     inp = pt.randn(*shape)
 
-    resblock = ResBlock(in_ch, out_ch, kernel_size, ndim=ndim)
+    resblock = ResBlock(in_ch, out_ch, kernel_size, n_dims=n_dims)
     out = resblock(inp)
 
     assert out.shape == (batch_size, out_ch, *spatial_dims)
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (2, 3, 32)), (2, (2, 3, 32, 32)), (3, (2, 3, 8, 16, 16))])
-def test_resblock_forward_with_scale(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (2, 3, 32)), (2, (2, 3, 32, 32)), (3, (2, 3, 8, 16, 16))])
+def test_resblock_forward_with_scale(n_dims, shape):
     """Test ResBlock forward pass with scaling."""
     batch_size, in_ch, *spatial_dims = shape
     out_ch = 64
@@ -27,14 +27,14 @@ def test_resblock_forward_with_scale(ndim, shape):
 
     inp = pt.randn(*shape)
 
-    resblock = ResBlock(in_ch, out_ch, kernel_size, ndim=ndim)
+    resblock = ResBlock(in_ch, out_ch, kernel_size, n_dims=n_dims)
     out = resblock(inp)
 
     assert out.shape == (batch_size, out_ch, *spatial_dims)
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (2, 3, 32)), (2, (2, 3, 32, 32)), (3, (2, 3, 8, 16, 16))])
-def test_resblock_forward_last_block(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (2, 3, 32)), (2, (2, 3, 32, 32)), (3, (2, 3, 8, 16, 16))])
+def test_resblock_forward_last_block(n_dims, shape):
     """Test ResBlock forward pass with last_block=True."""
     batch_size, in_ch, *spatial_dims = shape
     out_ch = 64
@@ -42,14 +42,14 @@ def test_resblock_forward_last_block(ndim, shape):
 
     inp = pt.randn(*shape)
 
-    resblock = ResBlock(in_ch, out_ch, kernel_size, ndim=ndim, last_block=True)
+    resblock = ResBlock(in_ch, out_ch, kernel_size, n_dims=n_dims, last_block=True)
     out = resblock(inp)
 
     assert out.shape == (batch_size, out_ch, *spatial_dims)
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (2, 3, 32)), (2, (2, 3, 32, 32)), (3, (2, 3, 8, 16, 16))])
-def test_resnet_forward(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (2, 3, 32)), (2, (2, 3, 32, 32)), (3, (2, 3, 8, 16, 16))])
+def test_resnet_forward(n_dims, shape):
     """Test Resnet forward pass."""
     batch_size, n_channels_in, *spatial_dims = shape
     n_channels_out = 64
@@ -59,14 +59,14 @@ def test_resnet_forward(ndim, shape):
 
     inp = pt.randn(*shape)
 
-    resnet = Resnet(n_channels_in, n_channels_out, n_layers, n_features, kernel_size, ndim=ndim)
+    resnet = Resnet(n_channels_in, n_channels_out, n_layers, n_features, kernel_size=kernel_size, n_dims=n_dims)
     out = resnet(inp.to(resnet.device))
 
     assert out.shape == (batch_size, n_channels_out, *spatial_dims)
 
 
-@pytest.mark.parametrize("ndim", [1, 2, 3])
-def test_resnet_init_params(ndim):
+@pytest.mark.parametrize("n_dims", [1, 2, 3])
+def test_resnet_init_params(n_dims):
     """Test Resnet initialization parameters."""
     n_channels_in = 3
     n_channels_out = 64
@@ -74,14 +74,14 @@ def test_resnet_init_params(ndim):
     n_features = 32
     kernel_size = 3
 
-    resnet = Resnet(n_channels_in, n_channels_out, n_layers, n_features, kernel_size, ndim=ndim)
+    resnet = Resnet(n_channels_in, n_channels_out, n_layers, n_features, kernel_size=kernel_size, n_dims=n_dims)
 
     assert resnet.init_params['n_channels_in'] == n_channels_in
     assert resnet.init_params['n_channels_out'] == n_channels_out
     assert resnet.init_params['n_layers'] == n_layers
     assert resnet.init_params['n_features'] == n_features
     assert resnet.init_params['kernel_size'] == kernel_size
-    assert resnet.init_params['ndim'] == ndim
+    assert resnet.init_params['n_dims'] == n_dims
 
 
 if __name__ == "__main__":

--- a/tests/models/test_unet.py
+++ b/tests/models/test_unet.py
@@ -14,44 +14,44 @@ def test_compute_architecture(n_skip):
     assert decoder[0] == (128, n_skip * (2 ** (n_levels - 1)) if n_skip is not None else None, 64)
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
-def test_conv_block(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
+def test_conv_block(n_dims, shape):
     """Test the ConvBlock class"""
-    block = ConvBlock(in_ch=3, out_ch=64, ndim=ndim, kernel_size=3)
+    block = ConvBlock(in_ch=3, out_ch=64, n_dims=n_dims, kernel_size=3)
     inp = pt.randn(*shape)
     out = block(inp)
     assert out.shape == (1, 64, *shape[2:])
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
-def test_double_conv(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
+def test_double_conv(n_dims, shape):
     """Test the DoubleConv class"""
-    block = DoubleConv(in_ch=3, out_ch=64, ndim=ndim)
+    block = DoubleConv(in_ch=3, out_ch=64, n_dims=n_dims)
     inp = pt.randn(*shape)
     out = block(inp)
     assert out.shape == (1, 64, *shape[2:])
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
-def test_down_block(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
+def test_down_block(n_dims, shape):
     """Test the DownBlock class"""
-    block = DownBlock(in_ch=3, out_ch=64, ndim=ndim)
+    block = DownBlock(in_ch=3, out_ch=64, n_dims=n_dims)
     inp = pt.randn(*shape)
     out = block(inp)
     expected_shape = tuple(s // 2 for s in shape[2:])
     assert out.shape == (1, 64, *expected_shape)
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 64, 32)), (2, (1, 64, 32, 32)), (3, (1, 64, 8, 16, 16))])
-def test_up_block(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 64, 32)), (2, (1, 64, 32, 32)), (3, (1, 64, 8, 16, 16))])
+def test_up_block(n_dims, shape):
     """Test the UpBlock class"""
-    block = UpBlock(in_ch=shape[1], skip_ch=None, out_ch=32, ndim=ndim)
+    block = UpBlock(in_ch=shape[1], skip_ch=None, out_ch=32, n_dims=n_dims)
     inp_lo_res = pt.randn(*shape)
     inp_hi_res = pt.randn(*shape[:2], *(s * 2 for s in shape[2:]))
     out = block(inp_lo_res, inp_hi_res)
     assert out.shape == (shape[0], 32, *(s * 2 for s in shape[2:]))
 
-    block = UpBlock(in_ch=shape[1], skip_ch=8, out_ch=32, ndim=ndim)
+    block = UpBlock(in_ch=shape[1], skip_ch=8, out_ch=32, n_dims=n_dims)
     inp_lo_res = pt.randn(*shape)
     inp_hi_res = pt.randn(*shape[:2], *(s * 2 for s in shape[2:]))
     out = block(inp_lo_res, inp_hi_res)
@@ -67,19 +67,19 @@ def test_unet_initialization():
     assert len(model.decoder_layers) == 3
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
-def test_unet_forward_pass(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
+def test_unet_forward_pass(n_dims, shape):
     """Test the UNet forward pass"""
-    model = UNet(n_channels_in=3, n_channels_out=1, ndim=ndim, n_features=32, n_levels=3)
+    model = UNet(n_channels_in=3, n_channels_out=1, n_dims=n_dims, n_features=32, n_levels=3)
     inp = pt.randn(*shape, device=model.device)
     out = model(inp)
     assert out.shape == (1, 1, *shape[2:])
 
 
-@pytest.mark.parametrize("ndim,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
-def test_unet_forward_pass_with_latent(ndim, shape):
+@pytest.mark.parametrize("n_dims,shape", [(1, (1, 3, 64)), (2, (1, 3, 64, 64)), (3, (1, 3, 16, 32, 32))])
+def test_unet_forward_pass_with_latent(n_dims, shape):
     """Test the UNet forward pass with latent return"""
-    model = UNet(n_channels_in=3, n_channels_out=1, ndim=ndim, n_features=32, n_levels=3)
+    model = UNet(n_channels_in=3, n_channels_out=1, n_dims=n_dims, n_features=32, n_levels=3)
     inp = pt.randn(*shape, device=model.device)
     out, latent = model(inp, return_latent=True)
     assert out.shape == (1, 1, *shape[2:])

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -25,7 +25,7 @@ def test_loss_tv_2d(setup):
     """Test for 2D Total Variation loss."""
     batch_size, channels, height, width, lambda_val = setup
     img = pt.randn(batch_size, channels, height, width, requires_grad=True)
-    loss_fn = LossTV(lambda_val=lambda_val, isotropic=True, ndims=2)
+    loss_fn = LossTV(lambda_val=lambda_val, isotropic=True, n_dims=2)
     loss = loss_fn(img)
     assert loss.requires_grad
     assert loss.item() > 0
@@ -35,7 +35,7 @@ def test_loss_tv_3d(setup):
     """Test for 3D Total Variation loss."""
     batch_size, channels, height, width, lambda_val = setup
     img = pt.randn(batch_size, channels, height, height, width, requires_grad=True)
-    loss_fn = LossTV(lambda_val=lambda_val, isotropic=True, ndims=3)
+    loss_fn = LossTV(lambda_val=lambda_val, isotropic=True, n_dims=3)
     loss = loss_fn(img)
     assert loss.requires_grad
     assert loss.item() > 0
@@ -45,7 +45,7 @@ def test_loss_tv_non_isotropic(setup):
     """Test for non-isotropic 2D Total Variation loss."""
     batch_size, channels, height, width, lambda_val = setup
     img = pt.randn(batch_size, channels, height, width, requires_grad=True)
-    loss_fn = LossTV(lambda_val=lambda_val, isotropic=False, ndims=2)
+    loss_fn = LossTV(lambda_val=lambda_val, isotropic=False, n_dims=2)
     loss = loss_fn(img)
     assert loss.requires_grad
     assert loss.item() > 0
@@ -55,7 +55,7 @@ def test_loss_tgv_2d(setup):
     """Test for 2D Total Generalized Variation loss."""
     batch_size, channels, height, width, lambda_val = setup
     img = pt.randn(batch_size, channels, height, width, requires_grad=True)
-    loss_fn = LossTGV(lambda_val=lambda_val, isotropic=True, ndims=2)
+    loss_fn = LossTGV(lambda_val=lambda_val, isotropic=True, n_dims=2)
     loss = loss_fn(img)
     assert loss.requires_grad
     assert loss.item() > 0
@@ -65,7 +65,7 @@ def test_loss_tgv_3d(setup):
     """Test for 3D Total Generalized Variation loss."""
     batch_size, channels, height, width, lambda_val = setup
     img = pt.randn(batch_size, channels, height, height, width, requires_grad=True)
-    loss_fn = LossTGV(lambda_val=lambda_val, isotropic=True, ndims=3)
+    loss_fn = LossTGV(lambda_val=lambda_val, isotropic=True, n_dims=3)
     loss = loss_fn(img)
     assert loss.requires_grad
     assert loss.item() > 0
@@ -75,7 +75,7 @@ def test_loss_tgv_non_isotropic(setup):
     """Test for non-isotropic 2D Total Generalized Variation loss."""
     batch_size, channels, height, width, lambda_val = setup
     img = pt.randn(batch_size, channels, height, width, requires_grad=True)
-    loss_fn = LossTGV(lambda_val=lambda_val, isotropic=False, ndims=2)
+    loss_fn = LossTGV(lambda_val=lambda_val, isotropic=False, n_dims=2)
     loss = loss_fn(img)
     assert loss.requires_grad
     assert loss.item() > 0
@@ -85,14 +85,14 @@ def test_invalid_input_tensor(setup):
     """Test for invalid input tensor."""
     batch_size, channels, height, width, lambda_val = setup
     img = pt.randn(batch_size, channels, height, requires_grad=True)  # 3D tensor instead of 4D
-    loss_fn = LossTV(lambda_val=lambda_val, isotropic=True, ndims=2)
+    loss_fn = LossTV(lambda_val=lambda_val, isotropic=True, n_dims=2)
     with pytest.raises(RuntimeError):
         loss_fn(img)
 
 
 def test_loss_tv_shape_mismatch():
     """Ensure LossTV raises the correct exception for shape mismatch."""
-    loss_fn = LossTV(lambda_val=0.1, ndims=2, isotropic=True)
+    loss_fn = LossTV(lambda_val=0.1, n_dims=2, isotropic=True)
     with pytest.raises(RuntimeError):
         tensor = pt.rand(3, 64, 64)  # Incorrect shape.
         loss_fn(tensor)
@@ -100,8 +100,8 @@ def test_loss_tv_shape_mismatch():
 
 def test_loss_tv_forward(random_tensor):
     """Test LossTV's forward method for isotropic and anisotropic settings."""
-    iso_loss_fn = LossTV(lambda_val=0.1, ndims=2, isotropic=True)
-    aniso_loss_fn = LossTV(lambda_val=0.1, ndims=2, isotropic=False)
+    iso_loss_fn = LossTV(lambda_val=0.1, n_dims=2, isotropic=True)
+    aniso_loss_fn = LossTV(lambda_val=0.1, n_dims=2, isotropic=False)
 
     # Check output for isotropic settings
     loss_iso = iso_loss_fn(random_tensor)
@@ -115,8 +115,8 @@ def test_loss_tv_forward(random_tensor):
 
 def test_loss_tgv_forward(random_tensor):
     """Test LossTGV's forward method for isotropic and anisotropic settings."""
-    iso_loss_tgv = LossTGV(lambda_val=0.1, ndims=2, isotropic=True)
-    aniso_loss_tgv = LossTGV(lambda_val=0.1, ndims=2, isotropic=False)
+    iso_loss_tgv = LossTGV(lambda_val=0.1, n_dims=2, isotropic=True)
+    aniso_loss_tgv = LossTGV(lambda_val=0.1, n_dims=2, isotropic=False)
 
     # Check output for isotropic settings
     loss_iso = iso_loss_tgv(random_tensor)
@@ -130,14 +130,14 @@ def test_loss_tgv_forward(random_tensor):
 
 def test_loss_tv_zero_input():
     """Test LossTV with zero input ensures the loss is zero."""
-    loss_fn = LossTV(lambda_val=0.1, ndims=2, isotropic=True)
+    loss_fn = LossTV(lambda_val=0.1, n_dims=2, isotropic=True)
     zero_tensor = pt.zeros(4, 3, 64, 64)
     assert loss_fn(zero_tensor).item() == pytest.approx(0.0), "Loss should be zero for zero input."
 
 
 def test_loss_tgv_zero_input():
     """Test LossTGV with zero input ensures the loss is zero."""
-    loss_fn = LossTGV(lambda_val=0.1, ndims=2, isotropic=True)
+    loss_fn = LossTGV(lambda_val=0.1, n_dims=2, isotropic=True)
     zero_tensor = pt.zeros(4, 3, 64, 64)
     assert loss_fn(zero_tensor).item() == pytest.approx(0.0), "Loss should be zero for zero input."
 


### PR DESCRIPTION
## Description

Following #2, this PR adds support for 1D and 3D signals in the algorithms.

## TODO

- [x] Implement support for 1D and 3D signals in the algorithms
- [x] Add/update docstring
- [x] Update tests
- [x] Add example
- [x] Add tutorial in documentation

## Notes

This does not add support for 2.5D processing of 3D data, but it is a prerequisite.