### PR TITLE
Add Attention to U-Net

### DIFF
--- a/src/autoden/algorithms/supervised.py
+++ b/src/autoden/algorithms/supervised.py
@@ -5,6 +5,7 @@ Supervised denoiser implementation.
 """
 
 from collections.abc import Sequence
+from typing import overload, Literal
 
 import numpy as np
 from numpy.typing import NDArray
@@ -20,7 +21,7 @@ class Supervised(Denoiser):
         inp: NDArray,
         tgt: NDArray,
         num_tst_ratio: float = 0.2,
-        strategy: str = "pixel-mask",
+        strategy: Literal["pixel-mask", "self-similar"] = "pixel-mask",
         channel_axis: int | None = None,
     ) -> tuple[NDArray, NDArray, NDArray | list[int]]:
         """

--- a/src/autoden/models/config.py
+++ b/src/autoden/models/config.py
@@ -155,6 +155,7 @@ class NetworkParamsUNet(NetworkParams):
         n_dims: int = 2,
         bilinear: bool = True,
         pad_mode: str = "replicate",
+        use_gated_att: bool = False,
     ) -> None:
         """Initialize the UNet network parameters definition.
 
@@ -182,6 +183,7 @@ class NetworkParamsUNet(NetworkParams):
         self.n_channels_skip = n_channels_skip
         self.bilinear = bilinear
         self.pad_mode = pad_mode
+        self.use_gated_att = use_gated_att
 
     def get_model(self, device: str = "cuda" if is_cuda_available() else "cpu") -> Module:
         """Get a U-net model with the selected parameters.
@@ -205,6 +207,7 @@ class NetworkParamsUNet(NetworkParams):
             n_dims=self.n_dims,
             bilinear=self.bilinear,
             pad_mode=self.pad_mode,
+            use_gated_att=self.use_gated_att,
             device=device,
         )
 

--- a/src/autoden/models/unet.py
+++ b/src/autoden/models/unet.py
@@ -9,7 +9,6 @@ from typing import overload, Literal
 import torch as pt
 import torch.nn as nn
 
-
 PAD_MODES = ("zeros", "replicate", "reflect", "circular")
 
 NDConv = {1: nn.Conv1d, 2: nn.Conv2d, 3: nn.Conv3d}
@@ -95,6 +94,42 @@ class DoubleConv(nn.Sequential):
         )
 
 
+class AttentionGate(nn.Module):
+    """Attention Gate as described in the Attention U-Net paper."""
+
+    def __init__(self, in_ch: int, gating_ch: int, n_dims: int = 2, pad_mode: str = "replicate"):
+        super().__init__()
+        self.n_dims = n_dims
+        self.pad_mode = pad_mode
+
+        # Convolution to reduce dimensions for attention
+        self.w_g = ConvBlock(gating_ch, gating_ch, n_dims=n_dims, kernel_size=1, pad_mode=pad_mode, last_block=True)
+        self.w_x = ConvBlock(in_ch, gating_ch, n_dims=n_dims, kernel_size=1, pad_mode=pad_mode, last_block=True, bias=False)
+        self.psi = nn.Sequential(
+            NDBatchNorm[n_dims](gating_ch),
+            nn.LeakyReLU(),
+            ConvBlock(gating_ch, 1, n_dims=n_dims, kernel_size=1, pad_mode=pad_mode, last_block=True),
+            nn.Sigmoid(),
+        )
+        self.w = nn.Sequential(
+            ConvBlock(in_ch, in_ch, n_dims=n_dims, kernel_size=1, pad_mode=pad_mode, last_block=True, bias=True),
+            NDBatchNorm[n_dims](gating_ch),
+        )
+
+    def forward(self, x: pt.Tensor, g: pt.Tensor) -> pt.Tensor:
+        # Upsample g to match x's spatial dimensions if needed
+        if g.shape[-self.n_dims :] != x.shape[-self.n_dims :]:
+            g = nn.functional.interpolate(g, size=x.shape[-self.n_dims :], mode=NDUpsampling[self.n_dims], align_corners=True)
+
+        # Compute attention coefficients
+        g_conv = self.w_g(g)
+        x_conv = self.w_x(x)
+        psi = self.psi(g_conv + x_conv)
+
+        # Apply attention to x
+        return self.w(x * psi)
+
+
 class DownBlock(nn.Sequential):
     """Down-scaling block."""
 
@@ -120,7 +155,14 @@ class UpBlock(nn.Module):
     """Up-scaling block."""
 
     def __init__(
-        self, in_ch: int, skip_ch: int | None, out_ch: int, n_dims: int = 2, linear: bool = True, pad_mode: str = "replicate"
+        self,
+        in_ch: int,
+        skip_ch: int | None,
+        out_ch: int,
+        n_dims: int = 2,
+        linear: bool = True,
+        pad_mode: str = "replicate",
+        use_gated_att: bool = True,
     ):
         super().__init__()
         self.skip_ch = skip_ch
@@ -138,6 +180,12 @@ class UpBlock(nn.Module):
                 self.skip_block = ConvBlock(in_ch, skip_ch, n_dims=n_dims, kernel_size=1, pad_mode=pad_mode)
         else:
             n_skip = in_ch
+
+        if use_gated_att:
+            self.att_gate = AttentionGate(n_skip, in_ch, n_dims=n_dims, pad_mode=pad_mode)
+        else:
+            self.att_gate = None
+
         self.conv_block = DoubleConv(in_ch + n_skip, out_ch, n_dims=n_dims, pad_mode=pad_mode)
 
     def forward(self, x_lo_res: pt.Tensor, x_hi_res: pt.Tensor) -> pt.Tensor:
@@ -146,14 +194,16 @@ class UpBlock(nn.Module):
             slice(0, s) for s in x_hi_res.shape[-self.n_dims :]
         ]
 
-        if self.skip_ch is None:
-            x_comb = pt.cat([x_hi_res, x_lo2hi_res[tuple(lo2hi_cropping)]], dim=1)
-        elif self.skip_ch > 0:
-            x_hi_res = self.skip_block(x_hi_res)
+        if isinstance(self.skip_ch, int) and self.skip_ch <= 0:
+            x_comb = x_lo2hi_res
+        else:
+            if isinstance(self.skip_ch, int) and self.skip_ch > 0:
+                x_hi_res = self.skip_block(x_hi_res)
+
+            if self.att_gate is not None:
+                x_hi_res = self.att_gate(x_hi_res, x_lo2hi_res[tuple(lo2hi_cropping)])
 
             x_comb = pt.cat([x_hi_res, x_lo2hi_res[tuple(lo2hi_cropping)]], dim=1)
-        else:
-            x_comb = x_lo2hi_res
 
         return self.conv_block(x_comb)
 
@@ -206,6 +256,7 @@ class UNet(nn.Module):
         n_channels_skip: int | None = None,
         bilinear: bool = True,
         pad_mode: str = "replicate",
+        use_gated_att: bool = False,
         device: str = "cuda" if pt.cuda.is_available() else "cpu",
         verbose: bool = False,
     ):
@@ -229,7 +280,7 @@ class UNet(nn.Module):
             [DownBlock(*lvl, n_dims=n_dims, bilinear=bilinear, pad_mode=pad_mode) for lvl in encoder]
         )
         self.decoder_layers = nn.ModuleList(
-            [UpBlock(*lvl, n_dims=n_dims, linear=bilinear, pad_mode=pad_mode) for lvl in decoder]
+            [UpBlock(*lvl, n_dims=n_dims, linear=bilinear, pad_mode=pad_mode, use_gated_att=use_gated_att) for lvl in decoder]
         )
         self.out_layer = ConvBlock(
             n_features, n_channels_out, n_dims=n_dims, kernel_size=1, pad_mode=pad_mode, last_block=True


### PR DESCRIPTION
## Description / Context

Attention mechanisms promise to improve the output quality of neural networks. Various types of attention have been developed for CNNs, and they find their use in various places of the architecture and applications. Attention is supposed to highlight the regions that the U-Net should be focusing on, and reduce the importance of non-important regions. This can be extremely beneficial for segmentation, but the use for denoising and inverse problems remains to be demonstrated and quantified.

## TODO

- [ ] Implement attention in the upscaling block:
  - [ ] Gated Attention
  - [ ] Cross-Attention
  - [ ] Self-Attention
- [ ] Implement attention in the bottleneck:
  - [ ] CBAM (as spectral and spatial)
- [ ] Add/update documentation
- [ ] Add/update examples
- [ ] Add/update tests

## Notes

Here is a small list of a few examples of attention blocks:
[1] J. Schlemper et al., “Attention gated networks: Learning to leverage salient regions in medical images,” Med. Image Anal., vol. 53, pp. 197–207, Apr. 2019, doi: 10.1016/j.media.2019.01.012.
[2] S. Woo, J. Park, J.-Y. Lee, and I. S. Kweon, “CBAM: Convolutional Block Attention Module,” in European Conference on Computer Vision, ACM, 2018, pp. 3–19. doi: 10.1007/978-3-030-01234-2_1.
